### PR TITLE
Nixify deps

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,1 @@
 packages: .
-source-repository-package
-  type: git
-  location: https://github.com/haskell/base64-bytestring
-
-  -- Version 1.0.1.0 is yet to be released
-  tag:  0a45c689b168a3557ba60f5845ad1d76572352aa
-

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -58,7 +58,7 @@ executable server
     bytestring,
     uuid,
     base64-bytestring,
-    Spock,
+    scotty,
     wai,
     wai-middleware-static,
     text,

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -7,7 +7,7 @@ build-type: Simple
 
 common sanity
   default-language: Haskell2010
-  build-depends: base ^>= 4.12
+  build-depends: base
   ghc-options:
     -Wall
     -Wmissing-export-lists
@@ -31,7 +31,7 @@ library
     binary,
     aeson,
     bytestring,
-    base64-bytestring >= 1.0.1.0,
+    base64-bytestring,
     containers,
     cryptonite,
     cborg,
@@ -57,7 +57,7 @@ executable server
     fido2,
     bytestring,
     uuid,
-    base64-bytestring >= 1.0.1.0,
+    base64-bytestring,
     Spock,
     wai,
     wai-middleware-static,

--- a/nix/haskell-deps.nix
+++ b/nix/haskell-deps.nix
@@ -1,0 +1,28 @@
+# File which provides a callback taking an argument haskellPackages and
+# selecting all the required packages for building the library.
+haskellPackages:
+  with haskellPackages;
+    [
+      aeson
+      aeson-qq
+      base64-bytestring
+      binary
+      bytestring
+      cborg
+      containers
+      cryptonite
+      http-types
+      scientific
+      scotty
+      serialise
+      tasty
+      tasty-hunit
+      text
+      unordered-containers
+      uuid
+      vector
+      wai
+      wai-middleware-static
+      warp
+      x509
+    ]

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,19 @@
 let
   pkgs = (import (import ./nix/sources.nix).nixpkgs) {};
-  ghc = pkgs.haskellPackages.ghcWithPackages (import ./nix/haskell-deps.nix);
+  haskellPackages = pkgs.haskellPackages.override {
+    overrides = self: super: {
+      cborg = pkgs.haskell.lib.overrideCabal super.cborg {
+        version = "0.2.3.0";
+        sha256 = "14y7yckj1xzldadyq8g84dgsdaygf9ss0gd38vjfw62smdjq1in8";
+      };
+      base64-bytestring = pkgs.haskell.lib.overrideCabal super.base64-bytestring {
+        version = "1.1.0.0";
+        # sha256 = pkgs.lib.fakeSha256;
+        sha256 = "1adcnkcx4nh3d59k94bkndj0wkgbvchz576qwlpaa7148a86q391";
+      };
+    };
+  };
+  ghc = haskellPackages.ghcWithPackages (import ./nix/haskell-deps.nix);
 in
 pkgs.mkShell rec {
   name = "fido2-devshell";

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,11 @@
 let
   pkgs = (import (import ./nix/sources.nix).nixpkgs) {};
+  ghc = pkgs.haskellPackages.ghcWithPackages (import ./nix/haskell-deps.nix);
 in
 pkgs.mkShell rec {
   name = "shell-file";
   buildInputs = [
-    pkgs.haskell.compiler.ghc865
+    ghc
     pkgs.cabal-install
     pkgs.pkg-config
     pkgs.entr

--- a/shell.nix
+++ b/shell.nix
@@ -3,18 +3,18 @@ let
   ghc = pkgs.haskellPackages.ghcWithPackages (import ./nix/haskell-deps.nix);
 in
 pkgs.mkShell rec {
-  name = "shell-file";
+  name = "fido2-devshell";
   buildInputs = [
     ghc
     pkgs.cabal-install
-    pkgs.pkg-config
     pkgs.entr
+    pkgs.pkg-config
     pkgs.yarn
   ];
   nativeBuildInputs = [
-    pkgs.zlib
     pkgs.gmp
     pkgs.ncurses
+    pkgs.zlib
   ];
   shellHook = ''
     export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath nativeBuildInputs}:$LD_LIBRARY_PATH


### PR DESCRIPTION
This PR adds `haskell-deps.nix` and sources it in the Nix shell environment. This allows us to use Nix's binary caches in local development and means we don't need new users to recompile the entire ecosystem for a from source build.

Up next: binary caching and CI.