### PR TITLE
Add SQLite backend to example server

### DIFF
--- a/fido/Crypto/Fido2/Protocol.hs
+++ b/fido/Crypto/Fido2/Protocol.hs
@@ -30,6 +30,7 @@ module Crypto.Fido2.Protocol
     PublicKeyCredential (..),
     WebauthnType (..),
     UserId (..),
+    Ec2Key (..),
     newUserId,
     Challenge,
     newChallenge,

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -53,22 +53,23 @@ executable server
   build-depends:
     aeson,
     aeson-qq,
-    containers,
-    cryptonite,
-    cookie,
-    fido2,
-    bytestring,
     base64-bytestring,
+    bytestring,
+    containers,
+    cookie,
+    cryptonite,
+    fido2,
+    http-types,
+    mtl,
     scotty,
+    sqlite-simple,
     stm,
+    text,
+    transformers,
     uuid,
     wai,
     wai-middleware-static,
-    text,
-    transformers,
-    mtl,
     warp,
-    http-types
 
 test-suite tests
   import: sanity

--- a/fido2.nix
+++ b/fido2.nix
@@ -1,8 +1,9 @@
 { mkDerivation, aeson, aeson-qq, base, base64-bytestring, binary
 , bytestring, cborg, containers, cookie, cryptonite, directory
 , filepath, hspec, http-types, mtl, scientific, scotty, serialise
-, stdenv, stm, text, transformers, unordered-containers, uuid
-, vector, wai, wai-middleware-static, warp, x509
+, sqlite-simple, stdenv, stm, text, transformers
+, unordered-containers, uuid, vector, wai, wai-middleware-static
+, warp, x509
 }:
 mkDerivation {
   pname = "fido2";
@@ -17,8 +18,8 @@ mkDerivation {
   ];
   executableHaskellDepends = [
     aeson aeson-qq base base64-bytestring bytestring containers cookie
-    cryptonite http-types mtl scotty stm text transformers uuid wai
-    wai-middleware-static warp
+    cryptonite http-types mtl scotty sqlite-simple stm text
+    transformers uuid wai wai-middleware-static warp
   ];
   testHaskellDepends = [
     aeson base bytestring directory filepath hspec

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -1,8 +1,17 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 module Database
-  ( addAttestedCredentialData
+  ( Connection
+  , Transaction () -- Constructor deliberately not exposed.
+  , addAttestedCredentialData
   , addUser
+  , addUserWithAttestedCredentialData
+  , begin
+  , commit
   , connect
+  , getUserByCredentialId
   , initialize
+  , rollback
   )
 where
 
@@ -16,6 +25,9 @@ import Crypto.Fido2.Protocol
 
 import qualified Crypto.Fido2.Protocol as Fido2
 import qualified Database.SQLite.Simple as Sqlite
+
+type Connection = Sqlite.Connection
+newtype Transaction = Transaction Sqlite.Connection
 
 connect :: IO Sqlite.Connection
 connect = do
@@ -48,29 +60,50 @@ initialize conn = do
     \ );                                                                       "
     ()
 
+  Sqlite.execute conn
+    " create index if not exists                                               \
+    \ ix_attested_credential_data_user_id                                      \
+    \ on attested_credential_data(user_id);                                    "
+    ()
+
+begin :: Sqlite.Connection -> IO Transaction
+begin conn = do
+  Sqlite.execute conn "begin;" ()
+  pure $ Transaction conn
+
+commit :: Transaction -> IO ()
+commit (Transaction conn) = Sqlite.execute conn "commit;" ()
+
+rollback :: Transaction -> IO ()
+rollback (Transaction conn) = Sqlite.execute conn "rollback;" ()
+
 addUser
-  :: Sqlite.Connection
-  -> Fido2.UserId
-  -> Text
-  -> Text
+  :: Transaction
+  -> Fido2.PublicKeyCredentialUserEntity
   -> IO ()
-addUser
-  conn (UserId (URLEncodedBase64 userId)) username displayName = do
+addUser (Transaction conn) user =
+  let
+    Fido2.PublicKeyCredentialUserEntity
+      { id = (UserId (URLEncodedBase64 userId))
+      , name = username
+      , displayName = displayName
+      } = user
+  in
     Sqlite.execute conn
       "insert into users (id, username, display_name) values (?, ?, ?);"
       (userId, username, displayName)
 
 addAttestedCredentialData
-  :: Sqlite.Connection
+  :: Transaction
   -> Fido2.UserId
   -> Fido2.CredentialId
   -> Fido2.Ec2Key
   -> IO ()
 addAttestedCredentialData
-  conn
+  (Transaction conn)
   (UserId (URLEncodedBase64 userId))
   (CredentialId (URLEncodedBase64 credentialId))
-  publicKey = do
+  publicKey =
     Sqlite.execute conn
       " insert into attested_credential_data                        \
       \ (id, user_id, public_key_curve, public_key_x, public_key_y) \
@@ -82,3 +115,29 @@ addAttestedCredentialData
       , Fido2.x publicKey
       , Fido2.y publicKey
       )
+
+addUserWithAttestedCredentialData
+  :: Transaction
+  -> Fido2.PublicKeyCredentialUserEntity
+  -> Fido2.CredentialId
+  -> Fido2.Ec2Key
+  -> IO ()
+addUserWithAttestedCredentialData tx user credentialId publicKey =
+  let
+    Fido2.PublicKeyCredentialUserEntity { id = userId } = user
+  in do
+    addUser tx user
+    addAttestedCredentialData tx userId credentialId publicKey
+
+getUserByCredentialId :: Transaction -> Fido2.CredentialId -> IO (Maybe Fido2.UserId)
+getUserByCredentialId
+  (Transaction conn)
+  (CredentialId (URLEncodedBase64 credentialId)) = do
+    result <- Sqlite.query
+      conn
+      "select user_id from attested_credential_data where id = ?;"
+      [credentialId]
+    case result of
+      []                   -> pure Nothing
+      [Sqlite.Only userId] -> pure $ Just $ UserId $ URLEncodedBase64 $ userId
+      _ -> fail "Unreachable: attested_credential_data.id has a unique index."

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -119,18 +119,6 @@ addAttestedCredentialData
         Fido2.y publicKey
       )
 
-addUserWithAttestedCredentialData ::
-  Transaction ->
-  Fido2.PublicKeyCredentialUserEntity ->
-  Fido2.CredentialId ->
-  Fido2.Ec2Key ->
-  IO ()
-addUserWithAttestedCredentialData tx user credentialId publicKey =
-  let Fido2.PublicKeyCredentialUserEntity {id = userId} = user
-   in do
-        addUser tx user
-        addAttestedCredentialData tx userId credentialId publicKey
-
 getUserByCredentialId :: Transaction -> Fido2.CredentialId -> IO (Maybe Fido2.UserId)
 getUserByCredentialId
   (Transaction conn)

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -1,0 +1,84 @@
+module Database
+  ( addAttestedCredentialData
+  , addUser
+  , connect
+  , initialize
+  )
+where
+
+import Data.Text (Text)
+import Crypto.Fido2.Protocol
+  ( URLEncodedBase64 (URLEncodedBase64)
+  , UserId (UserId)
+  , CredentialId (CredentialId)
+  , Ec2Key
+  )
+
+import qualified Crypto.Fido2.Protocol as Fido2
+import qualified Database.SQLite.Simple as Sqlite
+
+connect :: IO Sqlite.Connection
+connect = do
+  conn <- Sqlite.open "users.sqlite3"
+  Sqlite.execute conn "pragma foreign_keys = on;" ()
+  pure conn
+
+initialize :: Sqlite.Connection -> IO ()
+initialize conn = do
+  Sqlite.execute conn
+    " create table if not exists users                                         \
+    \ ( id           blob primary key                                          \
+    \ , username     text not null unique                                      \
+    \ , display_name text not null                                             \
+    \ , created      text not null                                             \
+    \                default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))           \
+    \ );                                                                       "
+    ()
+
+  Sqlite.execute conn
+    " create table if not exists attested_credential_data                      \
+    \ ( id               blob    primary key                                   \
+    \ , user_id          blob    not null                                      \
+    \ , public_key_curve integer not null                                      \
+    \ , public_key_x     blob    not null                                      \
+    \ , public_key_y     blob    not null                                      \
+    \ , created          text    not null                                      \
+    \                    default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))       \
+    \ , foreign key (user_id) references users (id)                            \
+    \ );                                                                       "
+    ()
+
+addUser
+  :: Sqlite.Connection
+  -> Fido2.UserId
+  -> Text
+  -> Text
+  -> IO ()
+addUser
+  conn (UserId (URLEncodedBase64 userId)) username displayName = do
+    Sqlite.execute conn
+      "insert into users (id, username, display_name) values (?, ?, ?);"
+      (userId, username, displayName)
+
+addAttestedCredentialData
+  :: Sqlite.Connection
+  -> Fido2.UserId
+  -> Fido2.CredentialId
+  -> Fido2.Ec2Key
+  -> IO ()
+addAttestedCredentialData
+  conn
+  (UserId (URLEncodedBase64 userId))
+  (CredentialId (URLEncodedBase64 credentialId))
+  publicKey = do
+    Sqlite.execute conn
+      " insert into attested_credential_data                        \
+      \ (id, user_id, public_key_curve, public_key_x, public_key_y) \
+      \ values                                                      \
+      \ (?, ?, ?, ?, ?);                                            "
+      ( credentialId
+      , userId
+      , Fido2.curve publicKey
+      , Fido2.x publicKey
+      , Fido2.y publicKey
+      )

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -1,34 +1,34 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Database
-  ( Connection
-  , Transaction () -- Constructor deliberately not exposed.
-  , addAttestedCredentialData
-  , addUser
-  , addUserWithAttestedCredentialData
-  , begin
-  , commit
-  , connect
-  , getUserByCredentialId
-  , getCredentialsByUserId
-  , getPublicKeyByCredentialId
-  , initialize
-  , rollback
+  ( Connection,
+    Transaction (), -- Constructor deliberately not exposed.
+    addAttestedCredentialData,
+    addUser,
+    addUserWithAttestedCredentialData,
+    begin,
+    commit,
+    connect,
+    getUserByCredentialId,
+    getCredentialsByUserId,
+    getPublicKeyByCredentialId,
+    initialize,
+    rollback,
   )
 where
 
-import Data.Text (Text)
 import Crypto.Fido2.Protocol
-  ( URLEncodedBase64 (URLEncodedBase64)
-  , UserId (UserId)
-  , CredentialId (CredentialId)
-  , Ec2Key
+  ( CredentialId (CredentialId),
+    Ec2Key,
+    URLEncodedBase64 (URLEncodedBase64),
+    UserId (UserId),
   )
-
 import qualified Crypto.Fido2.Protocol as Fido2
+import Data.Text (Text)
 import qualified Database.SQLite.Simple as Sqlite
 
 type Connection = Sqlite.Connection
+
 newtype Transaction = Transaction Sqlite.Connection
 
 connect :: IO Sqlite.Connection
@@ -39,7 +39,8 @@ connect = do
 
 initialize :: Sqlite.Connection -> IO ()
 initialize conn = do
-  Sqlite.execute conn
+  Sqlite.execute
+    conn
     " create table if not exists users                                         \
     \ ( id           blob primary key                                          \
     \ , username     text not null unique                                      \
@@ -48,8 +49,8 @@ initialize conn = do
     \                default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))           \
     \ );                                                                       "
     ()
-
-  Sqlite.execute conn
+  Sqlite.execute
+    conn
     " create table if not exists attested_credential_data                      \
     \ ( id               blob    primary key                                   \
     \ , user_id          blob    not null                                      \
@@ -61,8 +62,8 @@ initialize conn = do
     \ , foreign key (user_id) references users (id)                            \
     \ );                                                                       "
     ()
-
-  Sqlite.execute conn
+  Sqlite.execute
+    conn
     " create index if not exists                                               \
     \ ix_attested_credential_data_user_id                                      \
     \ on attested_credential_data(user_id);                                    "
@@ -79,92 +80,97 @@ commit (Transaction conn) = Sqlite.execute conn "commit;" ()
 rollback :: Transaction -> IO ()
 rollback (Transaction conn) = Sqlite.execute conn "rollback;" ()
 
-addUser
-  :: Transaction
-  -> Fido2.PublicKeyCredentialUserEntity
-  -> IO ()
+addUser ::
+  Transaction ->
+  Fido2.PublicKeyCredentialUserEntity ->
+  IO ()
 addUser (Transaction conn) user =
-  let
-    Fido2.PublicKeyCredentialUserEntity
-      { id = (UserId (URLEncodedBase64 userId))
-      , name = username
-      , displayName = displayName
-      } = user
-  in
-    Sqlite.execute conn
-      "insert into users (id, username, display_name) values (?, ?, ?);"
-      (userId, username, displayName)
+  let Fido2.PublicKeyCredentialUserEntity
+        { id = (UserId (URLEncodedBase64 userId)),
+          name = username,
+          displayName = displayName
+        } = user
+   in Sqlite.execute
+        conn
+        "insert into users (id, username, display_name) values (?, ?, ?);"
+        (userId, username, displayName)
 
-addAttestedCredentialData
-  :: Transaction
-  -> Fido2.UserId
-  -> Fido2.CredentialId
-  -> Fido2.Ec2Key
-  -> IO ()
+addAttestedCredentialData ::
+  Transaction ->
+  Fido2.UserId ->
+  Fido2.CredentialId ->
+  Fido2.Ec2Key ->
+  IO ()
 addAttestedCredentialData
   (Transaction conn)
   (UserId (URLEncodedBase64 userId))
   (CredentialId (URLEncodedBase64 credentialId))
   publicKey =
-    Sqlite.execute conn
+    Sqlite.execute
+      conn
       " insert into attested_credential_data                        \
       \ (id, user_id, public_key_curve, public_key_x, public_key_y) \
       \ values                                                      \
       \ (?, ?, ?, ?, ?);                                            "
-      ( credentialId
-      , userId
-      , Fido2.curve publicKey
-      , Fido2.x publicKey
-      , Fido2.y publicKey
+      ( credentialId,
+        userId,
+        Fido2.curve publicKey,
+        Fido2.x publicKey,
+        Fido2.y publicKey
       )
 
-addUserWithAttestedCredentialData
-  :: Transaction
-  -> Fido2.PublicKeyCredentialUserEntity
-  -> Fido2.CredentialId
-  -> Fido2.Ec2Key
-  -> IO ()
+addUserWithAttestedCredentialData ::
+  Transaction ->
+  Fido2.PublicKeyCredentialUserEntity ->
+  Fido2.CredentialId ->
+  Fido2.Ec2Key ->
+  IO ()
 addUserWithAttestedCredentialData tx user credentialId publicKey =
-  let
-    Fido2.PublicKeyCredentialUserEntity { id = userId } = user
-  in do
-    addUser tx user
-    addAttestedCredentialData tx userId credentialId publicKey
+  let Fido2.PublicKeyCredentialUserEntity {id = userId} = user
+   in do
+        addUser tx user
+        addAttestedCredentialData tx userId credentialId publicKey
 
 getUserByCredentialId :: Transaction -> Fido2.CredentialId -> IO (Maybe Fido2.UserId)
 getUserByCredentialId
   (Transaction conn)
   (CredentialId (URLEncodedBase64 credentialId)) = do
-    result <- Sqlite.query
-      conn
-      "select user_id from attested_credential_data where id = ?;"
-      [credentialId]
+    result <-
+      Sqlite.query
+        conn
+        "select user_id from attested_credential_data where id = ?;"
+        [credentialId]
     case result of
-      []                   -> pure Nothing
+      [] -> pure Nothing
       [Sqlite.Only userId] -> pure $ Just $ UserId $ URLEncodedBase64 $ userId
       _ -> fail "Unreachable: attested_credential_data.id has a unique index."
 
 getCredentialsByUserId :: Transaction -> Fido2.UserId -> IO [Fido2.CredentialId]
-getCredentialsByUserId (Transaction conn) (UserId (URLEncodedBase64 userId)) = do
-  credentialIds <- Sqlite.query
-    conn
-    "select id from attested_credential_data where user_id = ?;"
-    [userId]
-  pure $ fmap (CredentialId . URLEncodedBase64) credentialIds
+getCredentialsByUserId (Transaction conn) (UserId (URLEncodedBase64 userId)) =
+  let makeCredential (Sqlite.Only credentialId) =
+        CredentialId $ URLEncodedBase64 $ credentialId
+   in do
+        credentialIds <-
+          Sqlite.query
+            conn
+            "select id from attested_credential_data where user_id = ?;"
+            [userId]
+        pure $ fmap makeCredential credentialIds
 
-getPublicKeyByCredentialId
-  :: Transaction
-  -> Fido2.CredentialId
-  -> IO (Maybe Fido2.Ec2Key)
+getPublicKeyByCredentialId ::
+  Transaction ->
+  Fido2.CredentialId ->
+  IO (Maybe Fido2.Ec2Key)
 getPublicKeyByCredentialId
   (Transaction conn)
   (CredentialId (URLEncodedBase64 credentialId)) = do
-    result <- Sqlite.query
-      conn
-      " select (public_key_curve, public_key_x, public_key_y) \
-      \ from attested_credential_data                         \
-      \ where id = ?;                                         "
-      [credentialId]
+    result <-
+      Sqlite.query
+        conn
+        " select (public_key_curve, public_key_x, public_key_y) \
+        \ from attested_credential_data                         \
+        \ where id = ?;                                         "
+        [credentialId]
     case result of
-      []              -> pure Nothing
-      [(curve, x, y)] -> pure $ Just $ Fido2.Ec2Key { curve, x, y }
+      [] -> pure Nothing
+      [(curve, x, y)] -> pure $ Just $ Fido2.Ec2Key {curve, x, y}

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -30,14 +30,13 @@ import qualified Data.Text.Lazy.Encoding as LText
 import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
+import qualified Database
 import GHC.Generics (Generic)
 import qualified Network.HTTP.Types as HTTP
 import Network.Wai.Middleware.Static (addBase, staticPolicy)
 import qualified Web.Cookie as Cookie
 import Web.Scotty (ScottyM)
 import qualified Web.Scotty as Scotty
-
-import qualified Database
 
 -- Generate a new session for the current user and expose it as a @SetCookie@.
 newSession :: TVar Sessions -> IO (SessionId, Session, Cookie.SetCookie)
@@ -258,11 +257,12 @@ app db sessions = do
     Scotty.json @Text $ "This should only be visible when authenticated"
 
 mkCredentialDescriptor :: Fido2.CredentialId -> Fido2.PublicKeyCredentialDescriptor
-mkCredentialDescriptor credentialId = Fido2.PublicKeyCredentialDescriptor
-  { typ = Fido2.PublicKey
-  , id = credentialId
-  , transports = Nothing
-  }
+mkCredentialDescriptor credentialId =
+  Fido2.PublicKeyCredentialDescriptor
+    { typ = Fido2.PublicKey,
+      id = credentialId,
+      transports = Nothing
+    }
 
 data RegistrationResult
   = Success
@@ -291,14 +291,16 @@ finishRegistration db sessions = do
       -- step 1 to 17
       -- We abort if we couldn't attest the credential
       attestedCredential@Fido2.AttestedCredentialData
-        { credentialId
-        , credentialPublicKey
-        } <- handleError $ verifyAttestationResponse
-          serverOrigin
-          (Fido2.RpId domain)
-          challenge
-          Fido2.UserVerificationPreferred
-          response
+        { credentialId,
+          credentialPublicKey
+        } <-
+        handleError $
+          verifyAttestationResponse
+            serverOrigin
+            (Fido2.RpId domain)
+            challenge
+            Fido2.UserVerificationPreferred
+            response
       -- if the credential was succesfully attested, we will see if the
       -- credential doesn't exist yet, and if it doesn't, insert it.
       tx <- liftIO $ Database.begin db
@@ -310,14 +312,14 @@ finishRegistration db sessions = do
         -- but we do want to add a new credential.
         Just existingUserId | userId == existingUserId -> pure ()
         Just _differentUserId -> handleError $ Left AlreadyRegistered
-      let
-        -- TODO: Put username and display name in the session on begin,
-        -- so we can get it back here.
-        fakeUser = Fido2.PublicKeyCredentialUserEntity
-          { Fido2.displayName = "Frederik Frederikson"
-          , Fido2.name = "Frederik Frederikson"
-          , Fido2.id = userId
-          }
+      let -- TODO: Put username and display name in the session on begin,
+          -- so we can get it back here.
+          fakeUser =
+            Fido2.PublicKeyCredentialUserEntity
+              { Fido2.displayName = "Frederik Frederikson",
+                Fido2.name = "Frederik Frederikson",
+                Fido2.id = userId
+              }
       liftIO $ do
         Database.addUserWithAttestedCredentialData tx fakeUser credentialId credentialPublicKey
         STM.atomically $ STM.modifyTVar sessions $ Map.insert sessionId (Authenticated userId)

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -311,12 +311,12 @@ finishRegistration db sessions = do
       -- if the credential was succesfully attested, we will see if the
       -- credential doesn't exist yet, and if it doesn't, insert it.
       tx <- liftIO $ Database.begin db
+      -- If a credential with this id existed already, it must belong to the
+      -- current user, otherwise it's an error. The spec allows removing the
+      -- credential from the old user instead, but we don't do that.
       existingUserId <- liftIO $ Database.getUserByCredentialId tx credentialId
       case existingUserId of
         Nothing -> pure ()
-        -- TODO(ruuda): Handle the case of the user existing,
-        -- in that case we do not want to insert the user again,
-        -- but we do want to add a new credential.
         Just existingUserId | userId == existingUserId -> pure ()
         Just _differentUserId -> handleError $ Left AlreadyRegistered
       liftIO $ do

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -37,6 +37,8 @@ import qualified Web.Cookie as Cookie
 import Web.Scotty (ScottyM)
 import qualified Web.Scotty as Scotty
 
+import qualified Database
+
 -- Generate a new session for the current user and expose it as a @SetCookie@.
 newSession :: TVar Sessions -> IO (SessionId, Session, Cookie.SetCookie)
 newSession sessions = do
@@ -320,6 +322,8 @@ serverOrigin = Fido2.Origin $ "http://" <> domain <> ":" <> (pack $ show port)
 
 main :: IO ()
 main = do
+  db <- Database.connect
+  Database.initialize db
   sessions <- STM.newTVarIO Map.empty
   users <- STM.newTVarIO (Map.empty, Map.empty)
   putStrLn "You can view the web-app at: http://localhost:8080/index.html"


### PR DESCRIPTION
(As programmed together at ZuriHac)

This adds a simple SQLite database that stores users, and attested credential data for users. This database replaces the previous `TVar Users`. There is a currently unused function `getPublicKeyByCredentialId` that can be used in the login-complete endpoint to get the public key to be used for verification.

This is really a toy example, we don't handle things like unique constraint violations. Also, some user-provided data is inserted directly into a blob column in the database. I’m not sure if there is a size limit on those in the parser, but there is probably a DoS vector there.