### PR TITLE
Sqlite rebased

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist-newstyle
 dist
 cabal.project.local
 cabal.project.local~
+*.sqlite3
+*.sqlite3-journal

--- a/fido/Crypto/Fido2/Assertion.hs
+++ b/fido/Crypto/Fido2/Assertion.hs
@@ -97,5 +97,5 @@ verifyAssertionResponse
     rawData' <- maybe (Left RawDataUnavailable) pure rawData
     let msg = rawData' <> (BA.convert clientDataHash)
         (Fido2.URLEncodedBase64 sig) = signature
-        verifyResult = Fido2.verifyEC publicKey msg sig
+        verifyResult = Fido2.verifyEcdsa publicKey msg sig
     when (not verifyResult) (Left InvalidSignature)

--- a/fido/Crypto/Fido2/Protocol.hs
+++ b/fido/Crypto/Fido2/Protocol.hs
@@ -42,9 +42,11 @@ module Crypto.Fido2.Protocol
     EncodingRules (..),
     PublicKey (..),
     verifyEC,
+    -- This will definitely change do not depend on it.
     publicKeyPoint,
     publicKeyX,
     publicKeyY,
+    mkPublicKey,
   )
 where
 
@@ -401,6 +403,16 @@ publicKeyY key =
     ECDSA.Point _x y -> y
     -- TODO: Does this ever happen?
     ECDSA.PointO -> error "Got PointO at infinity. We always expect a key with X and Y"
+
+-- Make a public key at the constant curve that we currently only support.
+mkPublicKey :: Integer -> Integer -> PublicKey
+mkPublicKey x y =
+  let curve = ECDSA.getCurveByName ECDSA.SEC_p256r1
+   in Ec2Key
+        ECDSA.PublicKey
+          { public_curve = curve,
+            public_q = ECDSA.Point x y
+          }
 
 -- | EC2 signatures are ASN.1 encoded
 --

--- a/fido/Crypto/Fido2/Protocol.hs
+++ b/fido/Crypto/Fido2/Protocol.hs
@@ -42,6 +42,9 @@ module Crypto.Fido2.Protocol
     EncodingRules (..),
     PublicKey (..),
     verifyEC,
+    publicKeyPoint,
+    publicKeyX,
+    publicKeyY,
   )
 where
 
@@ -379,6 +382,25 @@ instance Aeson.ToJSON URLEncodedBase64 where
 
 data PublicKey = Ec2Key ECDSA.PublicKey
   deriving (Show)
+
+publicKeyPoint :: PublicKey -> ECDSA.Point
+publicKeyPoint (Ec2Key key) =
+  let ECDSA.PublicKey {public_q} = key
+   in public_q
+
+publicKeyX :: PublicKey -> Integer
+publicKeyX key =
+  case publicKeyPoint key of
+    ECDSA.Point x _y -> x
+    -- TODO: Does this ever happen?
+    ECDSA.PointO -> error "Got PointO at infinity. We always expect a key with X and Y"
+
+publicKeyY :: PublicKey -> Integer
+publicKeyY key =
+  case publicKeyPoint key of
+    ECDSA.Point _x y -> y
+    -- TODO: Does this ever happen?
+    ECDSA.PointO -> error "Got PointO at infinity. We always expect a key with X and Y"
 
 -- | EC2 signatures are ASN.1 encoded
 --

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -52,6 +52,7 @@ executable server
   import: sanity
   hs-source-dirs: server
   main-is: Main.hs
+  other-modules: Database
 
   build-depends:
     aeson,

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -56,22 +56,23 @@ executable server
   build-depends:
     aeson,
     aeson-qq,
-    containers,
-    cryptonite,
-    cookie,
-    fido2,
-    bytestring,
     base64-bytestring,
+    bytestring,
+    containers,
+    cookie,
+    cryptonite,
+    fido2,
+    http-types,
+    mtl,
     scotty,
+    sqlite-simple,
     stm,
+    text,
+    transformers,
     uuid,
     wai,
     wai-middleware-static,
-    text,
-    transformers,
-    mtl,
     warp,
-    http-types
 
 test-suite tests
   import: sanity

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -58,6 +58,7 @@ executable server
     aeson,
     aeson-qq,
     base64-bytestring,
+    binary,
     bytestring,
     containers,
     cookie,

--- a/fido2.nix
+++ b/fido2.nix
@@ -17,8 +17,8 @@ mkDerivation {
     unordered-containers vector x509
   ];
   executableHaskellDepends = [
-    aeson aeson-qq base base64-bytestring bytestring containers cookie
-    cryptonite http-types mtl scotty sqlite-simple stm text
+    aeson aeson-qq base base64-bytestring binary bytestring containers
+    cookie cryptonite http-types mtl scotty sqlite-simple stm text
     transformers uuid wai wai-middleware-static warp
   ];
   testHaskellDepends = [

--- a/fido2.nix
+++ b/fido2.nix
@@ -1,9 +1,9 @@
 { mkDerivation, aeson, aeson-qq, asn1-encoding, base
 , base64-bytestring, binary, bytestring, cborg, containers, cookie
 , cryptonite, directory, filepath, hspec, http-types, memory, mtl
-, scientific, scotty, serialise, stdenv, stm, text, transformers
-, unordered-containers, uuid, vector, wai, wai-middleware-static
-, warp, x509
+, scientific, scotty, serialise, sqlite-simple, stdenv, stm, text
+, transformers, unordered-containers, uuid, vector, wai
+, wai-middleware-static, warp, x509
 }:
 mkDerivation {
   pname = "fido2";
@@ -18,8 +18,8 @@ mkDerivation {
   ];
   executableHaskellDepends = [
     aeson aeson-qq base base64-bytestring bytestring containers cookie
-    cryptonite http-types mtl scotty stm text transformers uuid wai
-    wai-middleware-static warp
+    cryptonite http-types mtl scotty sqlite-simple stm text
+    transformers uuid wai wai-middleware-static warp
   ];
   testHaskellDepends = [
     aeson base bytestring directory filepath hspec

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -2,35 +2,35 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Database
-  ( Connection
-  , Transaction () -- Constructor deliberately not exposed.
-  , addAttestedCredentialData
-  , addUser
-  , addUserWithAttestedCredentialData
-  , begin
-  , commit
-  , connect
-  , getUserByCredentialId
-  , getCredentialsByUserId
-  , getPublicKeyByCredentialId
-  , initialize
-  , rollback
+  ( Connection,
+    Transaction (), -- Constructor deliberately not exposed.
+    addAttestedCredentialData,
+    addUser,
+    addUserWithAttestedCredentialData,
+    begin,
+    commit,
+    connect,
+    getUserByCredentialId,
+    getCredentialsByUserId,
+    getPublicKeyByCredentialId,
+    initialize,
+    rollback,
   )
 where
 
-import Data.Text (Text)
 import Crypto.Fido2.Protocol
-  ( URLEncodedBase64 (URLEncodedBase64)
-  , UserId (UserId)
-  , CredentialId (CredentialId)
-  , PublicKey
+  ( CredentialId (CredentialId),
+    PublicKey,
+    URLEncodedBase64 (URLEncodedBase64),
+    UserId (UserId),
   )
-
 import qualified Crypto.Fido2.Protocol as Fido2
 import Data.ByteString (ByteString)
+import Data.Text (Text)
 import qualified Database.SQLite.Simple as Sqlite
 
 type Connection = Sqlite.Connection
+
 newtype Transaction = Transaction Sqlite.Connection
 
 connect :: IO Sqlite.Connection
@@ -41,7 +41,8 @@ connect = do
 
 initialize :: Sqlite.Connection -> IO ()
 initialize conn = do
-  Sqlite.execute conn
+  Sqlite.execute
+    conn
     " create table if not exists users                                         \
     \ ( id           blob primary key                                          \
     \ , username     text not null unique                                      \
@@ -50,8 +51,8 @@ initialize conn = do
     \                default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))           \
     \ );                                                                       "
     ()
-
-  Sqlite.execute conn
+  Sqlite.execute
+    conn
     " create table if not exists attested_credential_data                      \
     \ ( id               blob    primary key                                   \
     \ , user_id          blob    not null                                      \
@@ -62,8 +63,8 @@ initialize conn = do
     \ , foreign key (user_id) references users (id)                            \
     \ );                                                                       "
     ()
-
-  Sqlite.execute conn
+  Sqlite.execute
+    conn
     " create index if not exists                                               \
     \ ix_attested_credential_data_user_id                                      \
     \ on attested_credential_data(user_id);                                    "
@@ -80,91 +81,93 @@ commit (Transaction conn) = Sqlite.execute conn "commit;" ()
 rollback :: Transaction -> IO ()
 rollback (Transaction conn) = Sqlite.execute conn "rollback;" ()
 
-addUser
-  :: Transaction
-  -> Fido2.PublicKeyCredentialUserEntity
-  -> IO ()
+addUser ::
+  Transaction ->
+  Fido2.PublicKeyCredentialUserEntity ->
+  IO ()
 addUser (Transaction conn) user =
-  let
-    Fido2.PublicKeyCredentialUserEntity
-      { id = (UserId (URLEncodedBase64 userId))
-      , name = username
-      , displayName = displayName
-      } = user
-  in
-    Sqlite.execute conn
-      "insert into users (id, username, display_name) values (?, ?, ?);"
-      (userId, username, displayName)
+  let Fido2.PublicKeyCredentialUserEntity
+        { id = (UserId (URLEncodedBase64 userId)),
+          name = username,
+          displayName = displayName
+        } = user
+   in Sqlite.execute
+        conn
+        "insert into users (id, username, display_name) values (?, ?, ?);"
+        (userId, username, displayName)
 
-addAttestedCredentialData
-  :: Transaction
-  -> Fido2.UserId
-  -> Fido2.CredentialId
-  -> Fido2.PublicKey
-  -> IO ()
+addAttestedCredentialData ::
+  Transaction ->
+  Fido2.UserId ->
+  Fido2.CredentialId ->
+  Fido2.PublicKey ->
+  IO ()
 addAttestedCredentialData
   (Transaction conn)
   (UserId (URLEncodedBase64 userId))
   (CredentialId (URLEncodedBase64 credentialId))
   publicKey =
-    Sqlite.execute conn
+    Sqlite.execute
+      conn
       " insert into attested_credential_data                        \
       \ (id, user_id, public_key_x, public_key_y)                   \
       \ values                                                      \
       \ (?, ?, ?, ?);                                               "
-      ( credentialId
-      , userId
-      , Fido2.publicKeyX publicKey
-      , Fido2.publicKeyY publicKey
+      ( credentialId,
+        userId,
+        Fido2.publicKeyX publicKey,
+        Fido2.publicKeyY publicKey
       )
 
-addUserWithAttestedCredentialData
-  :: Transaction
-  -> Fido2.PublicKeyCredentialUserEntity
-  -> Fido2.CredentialId
-  -> Fido2.PublicKey
-  -> IO ()
+addUserWithAttestedCredentialData ::
+  Transaction ->
+  Fido2.PublicKeyCredentialUserEntity ->
+  Fido2.CredentialId ->
+  Fido2.PublicKey ->
+  IO ()
 addUserWithAttestedCredentialData tx user credentialId publicKey =
-  let
-    Fido2.PublicKeyCredentialUserEntity { id = userId } = user
-  in do
-    addUser tx user
-    addAttestedCredentialData tx userId credentialId publicKey
+  let Fido2.PublicKeyCredentialUserEntity {id = userId} = user
+   in do
+        addUser tx user
+        addAttestedCredentialData tx userId credentialId publicKey
 
 getUserByCredentialId :: Transaction -> Fido2.CredentialId -> IO (Maybe Fido2.UserId)
 getUserByCredentialId
   (Transaction conn)
   (CredentialId (URLEncodedBase64 credentialId)) = do
-    result <- Sqlite.query
-      conn
-      "select user_id from attested_credential_data where id = ?;"
-      [credentialId]
+    result <-
+      Sqlite.query
+        conn
+        "select user_id from attested_credential_data where id = ?;"
+        [credentialId]
     case result of
-      []                   -> pure Nothing
+      [] -> pure Nothing
       [Sqlite.Only userId] -> pure $ Just $ UserId $ URLEncodedBase64 $ userId
       _ -> fail "Unreachable: attested_credential_data.id has a unique index."
 
 getCredentialsByUserId :: Transaction -> Fido2.UserId -> IO [Fido2.CredentialId]
 getCredentialsByUserId (Transaction conn) (UserId (URLEncodedBase64 userId)) = do
-  credentialIds :: [[ByteString]] <- Sqlite.query
-    conn
-    "select id from attested_credential_data where user_id = ?;"
-    [userId]
+  credentialIds :: [[ByteString]] <-
+    Sqlite.query
+      conn
+      "select id from attested_credential_data where user_id = ?;"
+      [userId]
   pure $ fmap (CredentialId . URLEncodedBase64) $ concat credentialIds
 
-getPublicKeyByCredentialId
-  :: Transaction
-  -> Fido2.CredentialId
-  -> IO (Maybe Fido2.PublicKey)
+getPublicKeyByCredentialId ::
+  Transaction ->
+  Fido2.CredentialId ->
+  IO (Maybe Fido2.PublicKey)
 getPublicKeyByCredentialId
   (Transaction conn)
   (CredentialId (URLEncodedBase64 credentialId)) = do
-    result <- Sqlite.query
-      conn
-      " select (public_key_x, public_key_y) \
-      \ from attested_credential_data                         \
-      \ where id = ?;                                         "
-      [credentialId]
+    result <-
+      Sqlite.query
+        conn
+        " select (public_key_x, public_key_y) \
+        \ from attested_credential_data                         \
+        \ where id = ?;                                         "
+        [credentialId]
     case result of
       [] -> pure Nothing
       [(x, y)] -> pure $ Just $ Fido2.mkPublicKey x y

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -25,6 +25,7 @@ import Crypto.Fido2.Protocol
     UserId (UserId),
   )
 import qualified Crypto.Fido2.Protocol as Fido2
+import qualified Data.Binary as Binary
 import qualified Database.SQLite.Simple as Sqlite
 
 type Connection = Sqlite.Connection
@@ -124,8 +125,8 @@ addAttestedCredentialData
       \ (?, ?, ?, ?);                                               "
       ( credentialId,
         userId,
-        Fido2.publicKeyX publicKey,
-        Fido2.publicKeyY publicKey
+        Binary.encode $ Fido2.publicKeyX publicKey,
+        Binary.encode $ Fido2.publicKeyY publicKey
       )
 
 getUserByCredentialId :: Transaction -> Fido2.CredentialId -> IO (Maybe Fido2.UserId)
@@ -154,7 +155,7 @@ getCredentialsByUserId (Transaction conn) (UserId (URLEncodedBase64 userId)) = d
     mkCredential (id, x, y) =
       Assertion.Credential
         { id = CredentialId $ URLEncodedBase64 id,
-          publicKey = Fido2.mkPublicKey x y
+          publicKey = Fido2.mkPublicKey (Binary.decode x) (Binary.decode y)
         }
 
 getCredentialIdsByUserId :: Transaction -> Fido2.UserId -> IO [Fido2.CredentialId]

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -6,7 +6,6 @@ module Database
     Transaction (), -- Constructor deliberately not exposed.
     addAttestedCredentialData,
     addUser,
-    addUserWithAttestedCredentialData,
     begin,
     commit,
     connect,
@@ -118,18 +117,6 @@ addAttestedCredentialData
         Fido2.publicKeyX publicKey,
         Fido2.publicKeyY publicKey
       )
-
-addUserWithAttestedCredentialData ::
-  Transaction ->
-  Fido2.PublicKeyCredentialUserEntity ->
-  Fido2.CredentialId ->
-  Fido2.PublicKey ->
-  IO ()
-addUserWithAttestedCredentialData tx user credentialId publicKey =
-  let Fido2.PublicKeyCredentialUserEntity {id = userId} = user
-   in do
-        addUser tx user
-        addAttestedCredentialData tx userId credentialId publicKey
 
 getUserByCredentialId :: Transaction -> Fido2.CredentialId -> IO (Maybe Fido2.UserId)
 getUserByCredentialId

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -1,0 +1,82 @@
+module Database
+  ( addAttestedCredentialData
+  , addUser
+  , connect
+  , initialize
+  )
+where
+
+import Data.Text (Text)
+import Crypto.Fido2.Protocol
+  ( URLEncodedBase64 (URLEncodedBase64)
+  , UserId (UserId)
+  , CredentialId (CredentialId)
+  , PublicKey
+  )
+
+import qualified Crypto.Fido2.Protocol as Fido2
+import qualified Database.SQLite.Simple as Sqlite
+
+connect :: IO Sqlite.Connection
+connect = do
+  conn <- Sqlite.open "users.sqlite3"
+  Sqlite.execute conn "pragma foreign_keys = on;" ()
+  pure conn
+
+initialize :: Sqlite.Connection -> IO ()
+initialize conn = do
+  Sqlite.execute conn
+    " create table if not exists users                                         \
+    \ ( id           blob primary key                                          \
+    \ , username     text not null unique                                      \
+    \ , display_name text not null                                             \
+    \ , created      text not null                                             \
+    \                default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))           \
+    \ );                                                                       "
+    ()
+
+  Sqlite.execute conn
+    " create table if not exists attested_credential_data                      \
+    \ ( id               blob    primary key                                   \
+    \ , user_id          blob    not null                                      \
+    \ , public_key_x     blob    not null                                      \
+    \ , public_key_y     blob    not null                                      \
+    \ , created          text    not null                                      \
+    \                    default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))       \
+    \ , foreign key (user_id) references users (id)                            \
+    \ );                                                                       "
+    ()
+
+addUser
+  :: Sqlite.Connection
+  -> Fido2.UserId
+  -> Text
+  -> Text
+  -> IO ()
+addUser
+  conn (UserId (URLEncodedBase64 userId)) username displayName = do
+    Sqlite.execute conn
+      "insert into users (id, username, display_name) values (?, ?, ?);"
+      (userId, username, displayName)
+
+addAttestedCredentialData
+  :: Sqlite.Connection
+  -> Fido2.UserId
+  -> Fido2.CredentialId
+  -> Fido2.PublicKey
+  -> IO ()
+addAttestedCredentialData
+  conn
+  (UserId (URLEncodedBase64 userId))
+  (CredentialId (URLEncodedBase64 credentialId))
+  publicKey = do
+    Sqlite.execute conn
+      " insert into attested_credential_data                        \
+      \ (id, user_id, public_key_x, public_key_y)                   \
+      \ values                                                      \
+      \ (?, ?, ?, ?);                                               "
+      ( credentialId
+      , userId
+      , Fido2.publicKeyX publicKey
+      , Fido2.publicKeyY publicKey
+      )

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -5,6 +5,7 @@ module Database
     Transaction (), -- Constructor deliberately not exposed.
     addAttestedCredentialData,
     addUser,
+    withTransaction,
     begin,
     commit,
     connect,
@@ -66,6 +67,17 @@ initialize conn = do
     \ ix_attested_credential_data_user_id                                      \
     \ on attested_credential_data(user_id);                                    "
     ()
+
+-- | Run an action using `Sqlite.withTransaction`.
+--
+-- If exceptions occur within the transaciton, the transaction is aborted
+-- with `ROLLBACK TRANSACTION`. Otherwise, the transaction is committed using
+-- `COMMIT TRANSACTION`.
+--
+-- This ensures that we always close our transactions and don't leave them
+-- open when exceptions occur.
+withTransaction :: Sqlite.Connection -> (Transaction -> IO a) -> IO a
+withTransaction conn action = Sqlite.withTransaction conn (action (Transaction conn))
 
 begin :: Sqlite.Connection -> IO Transaction
 begin conn = do

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -6,15 +6,12 @@ module Database
     addAttestedCredentialData,
     addUser,
     withTransaction,
-    begin,
-    commit,
     connect,
     getUserByCredentialId,
     getCredentialIdsByUserId,
     getCredentialsByUserId,
     getPublicKeyByCredentialId,
     initialize,
-    rollback,
   )
 where
 
@@ -80,17 +77,6 @@ initialize conn = do
 -- open when exceptions occur.
 withTransaction :: Sqlite.Connection -> (Transaction -> IO a) -> IO a
 withTransaction conn action = Sqlite.withTransaction conn (action (Transaction conn))
-
-begin :: Sqlite.Connection -> IO Transaction
-begin conn = do
-  Sqlite.execute conn "begin;" ()
-  pure $ Transaction conn
-
-commit :: Transaction -> IO ()
-commit (Transaction conn) = Sqlite.execute conn "commit;" ()
-
-rollback :: Transaction -> IO ()
-rollback (Transaction conn) = Sqlite.execute conn "rollback;" ()
 
 addUser ::
   Transaction ->

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -10,7 +10,7 @@ module Database
     commit,
     connect,
     getUserByCredentialId,
-    getCredentialsByUserId,
+    getCredentialIdsByUserId,
     getPublicKeyByCredentialId,
     initialize,
     rollback,
@@ -132,8 +132,8 @@ getUserByCredentialId
       [Sqlite.Only userId] -> pure $ Just $ UserId $ URLEncodedBase64 $ userId
       _ -> fail "Unreachable: attested_credential_data.id has a unique index."
 
-getCredentialsByUserId :: Transaction -> Fido2.UserId -> IO [Fido2.CredentialId]
-getCredentialsByUserId (Transaction conn) (UserId (URLEncodedBase64 userId)) = do
+getCredentialIdsByUserId :: Transaction -> Fido2.UserId -> IO [Fido2.CredentialId]
+getCredentialIdsByUserId (Transaction conn) (UserId (URLEncodedBase64 userId)) = do
   credentialIds :: [[ByteString]] <-
     Sqlite.query
       conn

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -39,6 +39,8 @@ import qualified Web.Cookie as Cookie
 import Web.Scotty (ScottyM)
 import qualified Web.Scotty as Scotty
 
+import qualified Database
+
 -- Generate a new session for the current user and expose it as a @SetCookie@.
 newSession :: TVar Sessions -> IO (SessionId, Session, Cookie.SetCookie)
 newSession sessions = do
@@ -354,6 +356,8 @@ rpEntity = Fido2.PublicKeyCredentialRpEntity {id = Just (Fido2.RpId domain), nam
 
 main :: IO ()
 main = do
+  db <- Database.connect
+  Database.initialize db
   sessions <- STM.newTVarIO Map.empty
   users <- STM.newTVarIO (Map.empty, Map.empty)
   putStrLn "You can view the web-app at: http://localhost:8080/index.html"

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -313,12 +313,12 @@ completeRegistration db sessions = do
       -- if the credential was succesfully attested, we will see if the
       -- credential doesn't exist yet, and if it doesn't, insert it.
       tx <- liftIO $ Database.begin db
+      -- If a credential with this id existed already, it must belong to the
+      -- current user, otherwise it's an error. The spec allows removing the
+      -- credential from the old user instead, but we don't do that.
       existingUserId <- liftIO $ Database.getUserByCredentialId tx credentialId
       case existingUserId of
         Nothing -> pure ()
-        -- TODO(ruuda): Handle the case of the user existing,
-        -- in that case we do not want to insert the user again,
-        -- but we do want to add a new credential.
         Just existingUserId | userId == existingUserId -> pure ()
         Just _differentUserId -> handleError $ Left AlreadyRegistered
       liftIO $ do


### PR DESCRIPTION
This is https://github.com/arianvp/haskell-fido2/pull/15 rebased on the latest `master`.

I tried to preserve the original git history as much as possible, while also making the following changes:

 - Use `Fido2.PublicKey` instead of `Fido2.Ec2Key`
 - Move all HTTP logic into the individual handler functions that we have.
 - Add https://github.com/arianvp/haskell-fido2/commit/4d0597a2c0a64967d2c3f2a5d4096a9e313e1f04 to make the SQLite changes work nicely with the assertion module that I authored in https://github.com/arianvp/haskell-fido2/pull/14
 - Add minor tweaks to `.gitignore` and the Cabal file
 - Clean up a few warnings that resulted from rebasing.
 - Use `Data.Binary.{decode,encode}` before storing the public key parameters in the DB. (Otherwise, these can overflow).
 - Abort database transactions when exceptions occur. (Otherwise the connection remains in the transaction state causing subsequent requests to fail)

This now uses SQLite for the user state. Everything still seems to work now.