### PR TITLE
Proper public keys implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
         nix-shell --pure --packages cabal2nix --command "cabal2nix . > /tmp/fido2.nix.new"
         git diff --no-index fido2.nix /tmp/fido2.nix.new
 
-    - run: nix-build | tee path
+    - run: nix-build
     - uses: actions/upload-artifact@v2
       with:
         name: Coverage
-        path: "$(cat path)/share/hpc/vanilla/html/**/*"
+        path: "result/share/hpc/vanilla/html/**/*"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,9 @@ jobs:
         nix-shell --pure --packages cabal2nix --command "cabal2nix . > /tmp/fido2.nix.new"
         git diff --no-index fido2.nix /tmp/fido2.nix.new
 
-    - run: nix-build
+    - run: nix-build | tee path
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Coverage
+        path: "$(cat path)/share/hpc/vanilla/html/**/*"
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cabal.project.local
 cabal.project.local~
 *.sqlite3
 *.sqlite3-journal
+result

--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,7 @@ then haskellPackages.fido2.env.overrideAttrs (
       pkgs.fd
       pkgs.ormolu
       pkgs.ghcid
+      pkgs.hlint
       haskellPackages.ghcide
     ];
   }

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,9 @@ let
   pkgs = (import (import ./nix/sources.nix).nixpkgs) {};
   haskellPackages = pkgs.haskellPackages.override {
     overrides = self: super: {
-      fido2 = super.callPackage ./fido2.nix {};
+      fido2 = pkgs.haskell.lib.overrideCabal (super.callPackage ./fido2.nix {}) {
+        doCoverage = true;
+      };
       cborg = pkgs.haskell.lib.overrideCabal super.cborg {
         version = "0.2.3.0";
         # sha256 = pkgs.lib.fakeSha256;

--- a/fido/Crypto/Fido2/Assertion.hs
+++ b/fido/Crypto/Fido2/Assertion.hs
@@ -10,6 +10,8 @@ where
 
 import Control.Monad (when)
 import qualified Crypto.Fido2.Protocol as Fido2
+import qualified Crypto.Fido2.PublicKey as PublicKey
+import Crypto.Fido2.PublicKey (PublicKey)
 import qualified Crypto.Hash as Hash
 import qualified Data.ByteArray as BA
 import qualified Data.List as List
@@ -30,7 +32,7 @@ data Error
 
 -- | Domain type: combination of a user's ID and publickey. This should be eventually
 -- extracted into some opinionated module that builds on top of the actual protocol types.
-data Credential = Credential {id :: Fido2.CredentialId, publicKey :: Fido2.PublicKey}
+data Credential = Credential {id :: Fido2.CredentialId, publicKey :: PublicKey}
 
 -- | Domain type: configuration for our relying party. Should eventually be moved to
 -- some other opinionated module.
@@ -97,5 +99,5 @@ verifyAssertionResponse
     rawData' <- maybe (Left RawDataUnavailable) pure rawData
     let msg = rawData' <> (BA.convert clientDataHash)
         (Fido2.URLEncodedBase64 sig) = signature
-        verifyResult = Fido2.verifyEcdsa publicKey msg sig
+        verifyResult = PublicKey.verify publicKey msg sig
     when (not verifyResult) (Left InvalidSignature)

--- a/fido/Crypto/Fido2/Assertion.hs
+++ b/fido/Crypto/Fido2/Assertion.hs
@@ -10,10 +10,8 @@ where
 
 import Control.Monad (when)
 import qualified Crypto.Fido2.Protocol as Fido2
-import qualified Crypto.Fido2.PublicKey as PublicKey
 import Crypto.Fido2.PublicKey (PublicKey)
 import qualified Crypto.Hash as Hash
-import qualified Data.ByteArray as BA
 import qualified Data.List as List
 import qualified Data.Text.Encoding as Text
 
@@ -74,7 +72,7 @@ verifyAssertionResponse
     -- credential’s response's clientDataJSON, authenticatorData, and signature
     -- respectively.
     let Fido2.AuthenticatorAssertionResponse {clientData, authenticatorData, signature, userHandle = _userHandle} = response
-    let Fido2.ClientData {typ, challenge = clientChallenge, origin = clientOrigin, clientDataHash} = clientData
+    let Fido2.ClientData {typ, challenge = clientChallenge, origin = clientOrigin} = clientData
     -- 7. Verify that the value of C.type is the string webauthn.get.
     when (typ /= Fido2.Get) (Left UnsupportedClientDataType)
     -- 8. Verify that the value of C.challenge matches the challenge that was sent to
@@ -84,7 +82,7 @@ verifyAssertionResponse
     when (challenge /= clientChallenge) (Left ChallengeMismatch)
     -- 9. Verify that the value of C.origin matches the Relying Party's origin.
     when (origin /= clientOrigin) (Left OriginMismatch)
-    let Fido2.AuthenticatorData {userPresent, rpIdHash, userVerified, rawData} = authenticatorData
+    let Fido2.AuthenticatorData {userPresent, rpIdHash, userVerified} = authenticatorData
     -- 11. Verify that the rpIdHash in authData is the SHA-256 hash of the RP ID
     -- expected by the Relying Party.
     when (Hash.hash (Text.encodeUtf8 . Fido2.unRpId $ rpId) /= rpIdHash) $ Left RpIdMismatch
@@ -96,8 +94,6 @@ verifyAssertionResponse
     -- 15. Let hash be the result of computing a hash over the clientData using SHA-256.
     -- 16. Using the credential public key looked up in step 3, verify that sig is a
     -- valid signature over the binary concatenation of authData and hash.
-    rawData' <- maybe (Left RawDataUnavailable) pure rawData
-    let msg = rawData' <> (BA.convert clientDataHash)
-        (Fido2.URLEncodedBase64 sig) = signature
-        verifyResult = PublicKey.verify publicKey msg sig
+    let Fido2.URLEncodedBase64 sig = signature
+    let verifyResult = Fido2.verify publicKey authenticatorData clientData sig
     when (not verifyResult) (Left InvalidSignature)

--- a/fido/Crypto/Fido2/Attestation.hs
+++ b/fido/Crypto/Fido2/Attestation.hs
@@ -104,6 +104,7 @@ verifyAttestationResponse
     --
     -- --> This is implied in the decoder of 'AuthenticatorAttestationResponse'
     --
+    -- TODO(arianvp): We could lift this one to parsing phase; I suppose? Make invalid states unrepresentable
     -- 3. Verify that the value of C.type is webauthn.create.
     let ClientData {typ} = clientData
     when (typ /= Create) $ Left InvalidWebauthnType

--- a/fido/Crypto/Fido2/Protocol.hs
+++ b/fido/Crypto/Fido2/Protocol.hs
@@ -534,7 +534,7 @@ decodeAuthenticatorData originalBs x = do
 -- attestedcredentialdataheader knallen we in deze
 decodeAttestedCredentialData :: AttestedCredentialDataHeader -> Decoder s AttestedCredentialData
 decodeAttestedCredentialData (AttestedCredentialDataHeader aaguid credentialId) = do
-  AttestedCredentialData aaguid (CredentialId (URLEncodedBase64 credentialId)) <$> PublicKey.decodePublicKey
+  AttestedCredentialData aaguid (CredentialId (URLEncodedBase64 credentialId)) <$> Serialise.decode
 
 decodeAuthenticatorDataRaw :: Binary.Get AuthenticatorDataRaw
 decodeAuthenticatorDataRaw = do

--- a/fido/Crypto/Fido2/Protocol.hs
+++ b/fido/Crypto/Fido2/Protocol.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StrictData #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -31,7 +30,7 @@ module Crypto.Fido2.Protocol
     WebauthnType (..),
     UserId (..),
     newUserId,
-    Challenge,
+    Challenge(..),
     newChallenge,
     Timeout (..),
     PublicKeyCredentialType (..),

--- a/fido/Crypto/Fido2/Protocol.hs
+++ b/fido/Crypto/Fido2/Protocol.hs
@@ -34,37 +34,24 @@ module Crypto.Fido2.Protocol
     Challenge,
     newChallenge,
     Timeout (..),
-    COSEAlgorithmIdentifier (..),
     PublicKeyCredentialType (..),
     ResidentKeyRequirement (..),
     UserVerificationRequirement (..),
     AuthenticatorAttachment (..),
     EncodingRules (..),
-    verifyEcdsa,
-    -- This will probably change. Do not depend on it.
-    PublicKey,
-    publicKeyX,
-    publicKeyY,
-    mkEcdsaPublicKey,
   )
 where
 
 import Codec.CBOR.Decoding (Decoder)
 import qualified Codec.CBOR.Read as CBOR
-import qualified Codec.CBOR.Term as CBOR
-import Codec.CBOR.Term (Term (TBytes, TInt, TMap, TString))
+import Codec.CBOR.Term (Term (TBytes, TMap, TString))
 import qualified Codec.Serialise.Class as Serialise
-import Control.Monad (guard)
+import qualified Crypto.Fido2.PublicKey as PublicKey
+import Crypto.Fido2.PublicKey (COSEAlgorithmIdentifier, PublicKey)
 import qualified Crypto.Hash as Hash
 import Crypto.Hash (Digest, SHA256)
-import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
-import qualified Crypto.PubKey.ECC.Prim as ECDSA
-import qualified Crypto.PubKey.ECC.Types as ECDSA
 import qualified Crypto.Random as Random
 import Crypto.Random (MonadRandom)
-import qualified Data.ASN1.BinaryEncoding as ASN1
-import qualified Data.ASN1.Encoding as ASN1
-import qualified Data.ASN1.Prim as ASN1
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Internal as Aeson
@@ -75,13 +62,10 @@ import Data.Bifunctor (first)
 import qualified Data.Binary.Get as Binary
 import qualified Data.Bits as Bits
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64.URL as Base64
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HashMap
 import Data.HashMap.Strict (HashMap)
-import Data.IntMap.Strict (IntMap)
-import qualified Data.IntMap.Strict as IntMap
 import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
@@ -134,12 +118,6 @@ data PublicKeyCredential response
   deriving stock (Generic, Show)
   -- TODO use EncodingRules
   deriving (FromJSON) via (EncodingRules (PublicKeyCredential response))
-
-data COSEAlgorithmIdentifier = ES256
-  deriving stock (Show)
-
-instance ToJSON COSEAlgorithmIdentifier where
-  toJSON ES256 = Aeson.Number (-7)
 
 newtype Timeout = Timeout Word32
   deriving stock (Generic, Show)
@@ -381,10 +359,6 @@ instance Aeson.FromJSON URLEncodedBase64 where
 instance Aeson.ToJSON URLEncodedBase64 where
   toJSON (URLEncodedBase64 bs) = Aeson.toJSON . Text.decodeUtf8 . Base64.encodeUnpadded $ bs
 
--- TODO(#20): Support other types of keys / signatures.
-data PublicKey = Ecdsa {point :: Point, curveName :: ECDSA.CurveName}
-  deriving stock (Show)
-
 -- | We have our own type here because we want to avoid partial functions when
 -- getting the X and Y values on the public curve. (Otherwise we'd have to deal
 -- with the infinity point which should never occur in this program -- it's
@@ -400,71 +374,6 @@ data PublicKey = Ecdsa {point :: Point, curveName :: ECDSA.CurveName}
 -- [1]: https://tools.ietf.org/html/draft-ietf-cose-msg-24#section-13.1.1
 data Point = Point {x :: Integer, y :: Integer}
   deriving stock (Show)
-
-convertKeyToCryptonite :: PublicKey -> ECDSA.PublicKey
-convertKeyToCryptonite Ecdsa {point, curveName} =
-  let curve = ECDSA.getCurveByName curveName
-   in ECDSA.PublicKey {public_curve = curve, public_q = convertPointToCryptonite point}
-
-isPointValid :: ECDSA.Curve -> Point -> Bool
-isPointValid curve point = ECDSA.isPointValid curve (convertPointToCryptonite point)
-
-convertPointToCryptonite :: Point -> ECDSA.Point
-convertPointToCryptonite Point {x, y} = ECDSA.Point x y
-
-publicKeyX :: PublicKey -> Integer
-publicKeyX = x . point
-
-publicKeyY :: PublicKey -> Integer
-publicKeyY = y . point
-
-mkEcdsaPublicKey :: Integer -> Integer -> Maybe PublicKey
-mkEcdsaPublicKey x y = do
-  -- TODO(#22): Support other curves.
-  let curveName = ECDSA.SEC_p256r1
-      curve = ECDSA.getCurveByName curveName
-      point = Point {x, y}
-  guard $ isPointValid curve point
-  Just $ Ecdsa {curveName = curveName, point = point}
-
--- | Ecdsa signatures are ASN.1 encoded
---
--- ASN.1 decoding stolen from
--- https://hackage.haskell.org/package/x509-validation-1.6.11/docs/src/Data.X509.Validation.Signature.html#verifyECDSA
-decodeEcdsaSignature :: ByteString -> Maybe ECDSA.Signature
-decodeEcdsaSignature sigbs =
-  case ASN1.decodeASN1' ASN1.BER sigbs of
-    Left _ -> Nothing
-    Right [ASN1.Start ASN1.Sequence, ASN1.IntVal r, ASN1.IntVal s, ASN1.End ASN1.Sequence] ->
-      Just (ECDSA.Signature r s)
-    Right _ -> Nothing
-
--- | Convert an unsigned big endian octet sequence to the integer
--- it represents. Taken from @hs-jose@.
---
--- TODO: Test the crap out of this.
-bsToInteger :: ByteString -> Integer
-bsToInteger = BS.foldl (\acc x -> acc * 256 + toInteger x) 0
-
--- | Verify an Ecdsa signature. Taken from @hs-jose@.
---
--- TODO: Test the crap out of this.
---
--- For backwards compatibility reasons, the "signature" field is NOT
--- formatted as specified in COSE, but formatted as an ASN.1 pair
---
--- RSA keys are formatted as PKCS#1
--- and EdDSA keys are formatted as COSE (though this is unspecified)
--- https://github.com/w3c/webauthn/issues/1124#issuecomment-644008314
-verifyEcdsa ::
-  PublicKey ->
-  ByteString ->
-  ByteString ->
-  Bool
-verifyEcdsa publicKey message signature =
-  case decodeEcdsaSignature signature of
-    Nothing -> False
-    Just signature -> ECDSA.verify Hash.SHA256 (convertKeyToCryptonite publicKey) signature message
 
 data WebauthnType = Create | Get
   deriving (Eq, Show)
@@ -623,7 +532,7 @@ decodeAuthenticatorData originalBs x = do
 -- attestedcredentialdataheader knallen we in deze
 decodeAttestedCredentialData :: AttestedCredentialDataHeader -> Decoder s AttestedCredentialData
 decodeAttestedCredentialData (AttestedCredentialDataHeader aaguid credentialId) = do
-  AttestedCredentialData aaguid (CredentialId (URLEncodedBase64 credentialId)) <$> decodePublicKey
+  AttestedCredentialData aaguid (CredentialId (URLEncodedBase64 credentialId)) <$> PublicKey.decodePublicKey
 
 decodeAuthenticatorDataRaw :: Binary.Get AuthenticatorDataRaw
 decodeAuthenticatorDataRaw = do
@@ -659,22 +568,6 @@ decodeAttestationObjectRaw = do
   -- TODO flags should tell whether authData is present, no?
   TBytes authDataRaw <- maybe (fail "no authData") pure (HashMap.lookup "authData" map)
   pure $ AttestationObjectRaw authDataRaw fmt attStmt
-
--- TODO Make more generic
-decodePublicKey :: Decoder s PublicKey
-decodePublicKey = do
-  map :: (IntMap CBOR.Term) <- Serialise.decode
-  let key = do
-        keyType <- IntMap.lookup 1 map
-        guard $ keyType == TInt 2
-        alg <- IntMap.lookup 3 map
-        -- TODO(#20): Add support for multiple curves / key types.
-        guard $ alg == TInt (-7)
-        TInt _curve <- IntMap.lookup (-1) map
-        TBytes x <- IntMap.lookup (-2) map
-        TBytes y <- IntMap.lookup (-3) map
-        mkEcdsaPublicKey (bsToInteger x) (bsToInteger y)
-  maybe (fail "invalid key") pure key
 
 ----- Encoding utils
 

--- a/fido/Crypto/Fido2/Protocol.hs
+++ b/fido/Crypto/Fido2/Protocol.hs
@@ -30,7 +30,7 @@ module Crypto.Fido2.Protocol
     WebauthnType (..),
     UserId (..),
     newUserId,
-    Challenge(..),
+    Challenge (..),
     newChallenge,
     Timeout (..),
     PublicKeyCredentialType (..),

--- a/fido/Crypto/Fido2/PublicKey.hs
+++ b/fido/Crypto/Fido2/PublicKey.hs
@@ -7,10 +7,10 @@
 module Crypto.Fido2.PublicKey
   ( COSEAlgorithmIdentifier (..),
     ECDSAIdentifier (..),
-    CurveIdentifier (..),
-    PublicKey (..),
     EdDSAKey (..),
     ECDSAKey (..),
+    CurveIdentifier (..),
+    PublicKey (..),
     decodePublicKey,
     encodePublicKey,
     toCurve,
@@ -18,11 +18,11 @@ module Crypto.Fido2.PublicKey
   )
 where
 
-import Codec.Serialise.Class(encode, decode, Serialise)
 import qualified Codec.CBOR.Decoding as CBOR
 import Codec.CBOR.Decoding (Decoder)
 import qualified Codec.CBOR.Encoding as CBOR
 import Codec.CBOR.Encoding (Encoding)
+import Codec.Serialise.Class (Serialise, decode, encode)
 import Control.Monad (when)
 import Crypto.Error (CryptoFailable (CryptoFailed, CryptoPassed))
 import qualified Crypto.Hash.Algorithms as Hash
@@ -115,7 +115,6 @@ encodeKeyType :: KeyType -> Encoding
 encodeKeyType kty = CBOR.encodeInt $ case kty of
   OKP -> 1
   ECC -> 2
-
 
 instance Serialise PublicKey where
   decode = decodePublicKey

--- a/fido/Crypto/Fido2/PublicKey.hs
+++ b/fido/Crypto/Fido2/PublicKey.hs
@@ -1,0 +1,279 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+-- | Include
+module Crypto.Fido2.PublicKey
+  ( COSEAlgorithmIdentifier (..),
+    PublicKey,
+    decodePublicKey,
+    encodePublicKey,
+    verify,
+  )
+where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import Codec.CBOR.Decoding (Decoder)
+import qualified Codec.CBOR.Encoding as CBOR
+import Codec.CBOR.Encoding (Encoding)
+import Control.Monad (when)
+import Crypto.Error (CryptoFailable (CryptoFailed, CryptoPassed))
+import qualified Crypto.Hash.Algorithms as Hash
+import Crypto.Number.Serialize (i2osp, os2ip)
+import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
+import qualified Crypto.PubKey.ECC.Generate as ECC
+import qualified Crypto.PubKey.ECC.Prim as ECC
+import qualified Crypto.PubKey.ECC.Types as ECC
+import qualified Crypto.PubKey.Ed25519 as Ed25519
+import qualified Crypto.PubKey.Ed448 as Ed448
+import Crypto.Random (drgNewSeed, seedFromInteger, withDRG)
+import qualified Data.ASN1.BinaryEncoding as ASN1
+import qualified Data.ASN1.Encoding as ASN1
+import qualified Data.ASN1.Prim as ASN1
+import Data.Aeson.Types (ToJSON (toJSON))
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteArray as ByteArray
+import Data.ByteString (ByteString)
+import Test.QuickCheck (Arbitrary, Gen, arbitrary, elements, oneof)
+
+data ECDSAIdentifier
+  = ES256
+  | ES384
+  | ES512
+  deriving (Show, Eq)
+
+data COSEAlgorithmIdentifier
+  = ECDSAIdentifier ECDSAIdentifier
+  | EdDSA
+  deriving (Show, Eq)
+
+instance Arbitrary COSEAlgorithmIdentifier where
+  arbitrary = oneof [pure EdDSA, ECDSAIdentifier <$> elements [ES256, ES384, ES512]]
+
+-- All CBOR is encoded using
+-- https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#ctap2-canonical-cbor-encoding-form
+
+--
+-- a signature decoding uniquely belongs to an algorithm identifier. how do we
+-- encode this correspondence?
+decodeCOSEAlgorithmIdentifier :: Decoder s COSEAlgorithmIdentifier
+decodeCOSEAlgorithmIdentifier =
+  toAlg =<< CBOR.decodeIntCanonical
+  where
+    toAlg (-7) = pure $ ECDSAIdentifier ES256
+    toAlg (-35) = pure $ ECDSAIdentifier ES384
+    toAlg (-36) = pure $ ECDSAIdentifier ES512
+    toAlg (-8) = pure EdDSA
+    toAlg _ = fail "Unsupported `alg`"
+
+instance ToJSON COSEAlgorithmIdentifier where
+  toJSON (ECDSAIdentifier ES256) = Aeson.Number (-7)
+  toJSON (ECDSAIdentifier ES384) = Aeson.Number (-35)
+  toJSON (ECDSAIdentifier ES512) = Aeson.Number (-36)
+  toJSON EdDSA = Aeson.Number (-8)
+
+data EdDSAKey
+  = Ed25519 Ed25519.PublicKey
+  | Ed448 Ed448.PublicKey
+  deriving (Eq, Show)
+
+instance Arbitrary EdDSAKey where
+  arbitrary =
+    oneof
+      [ Ed25519 <$> randomKey1,
+        Ed448 <$> randomKey2
+      ]
+
+randomKey1 :: Gen Ed25519.PublicKey
+randomKey1 = do
+  rng <- drgNewSeed . seedFromInteger <$> arbitrary
+  let (a, _) = withDRG rng (Ed25519.toPublic <$> Ed25519.generateSecretKey)
+  pure a
+
+randomKey2 :: Gen Ed448.PublicKey
+randomKey2 = do
+  rng <- drgNewSeed . seedFromInteger <$> arbitrary
+  let (a, _) = withDRG rng (Ed448.toPublic <$> Ed448.generateSecretKey)
+  pure a
+
+randomKey3 :: Gen ECDSA.PublicKey
+randomKey3 = do
+  curve <- elements [ECC.SEC_p256r1, ECC.SEC_p384r1, ECC.SEC_p521r1]
+  rng <- drgNewSeed . seedFromInteger <$> arbitrary
+  let ((pub, _), _) = withDRG rng (ECC.generate (ECC.getCurveByName curve))
+  pure pub
+
+data ECDSAKey = ECDSAKey ECDSAIdentifier ECDSA.PublicKey deriving (Eq, Show)
+
+instance Arbitrary ECDSAKey where
+  arbitrary =
+    oneof
+      [ ECDSAKey ES256 <$> randomKey3,
+        ECDSAKey ES384 <$> randomKey3,
+        ECDSAKey ES512 <$> randomKey3
+      ]
+
+data PublicKey
+  = EdDSAPublicKey EdDSAKey
+  | ECDSAPublicKey ECDSAKey
+  deriving (Show, Eq)
+
+instance Arbitrary PublicKey where
+  arbitrary = oneof [EdDSAPublicKey <$> arbitrary, ECDSAPublicKey <$> arbitrary]
+
+-- | The credential public key encoded in COSE_Key format, as defined in Section 7
+-- of [RFC8152], using the CTAP2 canonical CBOR encoding form. The
+-- COSE_Key-encoded credential public key MUST contain the "alg" parameter and
+-- MUST NOT contain any other OPTIONAL parameters. The "alg" parameter MUST
+-- contain a COSEAlgorithmIdentifier value. The encoded credential public key
+-- MUST also contain any additional REQUIRED parameters stipulated by the
+-- relevant key type specification, i.e., REQUIRED for the key type "kty" and
+-- algorithm "alg" (see Section 8 of [RFC8152]).
+--
+-- Furthermore: CBOR values are CTAP2 canonical encoded.
+-- https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#ctap2-canonical-cbor-encoding-form
+decodePublicKey :: Decoder s PublicKey
+decodePublicKey = do
+  _n <- CBOR.decodeMapLenCanonical
+  ktyKey <- CBOR.decodeIntCanonical
+  when (ktyKey /= 1) $ fail "Expected required `kty`"
+  kty <- CBOR.decodeIntCanonical
+  case kty of
+    1 -> EdDSAPublicKey <$> decodeEdDSAKey
+    2 -> ECDSAPublicKey <$> decodeECDSAPublicKey
+    x -> fail $ "unexpected kty: " ++ show x
+
+decodeEdDSAKey :: Decoder s EdDSAKey
+decodeEdDSAKey = do
+  algKey <- CBOR.decodeIntCanonical
+  when (algKey /= 3) $ fail "Expected required `alg`"
+  alg <- decodeCOSEAlgorithmIdentifier
+  when (alg /= EdDSA) $ fail "Unsupported `alg`"
+  crvKey <- CBOR.decodeIntCanonical
+  when (crvKey /= (-1)) $ fail "Expected required `crv`"
+  crv <- CBOR.decodeIntCanonical
+  xKey <- CBOR.decodeIntCanonical
+  when (xKey /= -2) $ fail "Expected required `x`"
+  x <- CBOR.decodeBytesCanonical
+  case crv of
+    6 ->
+      case Ed25519.publicKey x of
+        CryptoFailed e -> fail (show e)
+        CryptoPassed a -> pure $ Ed25519 a
+    7 ->
+      case Ed448.publicKey x of
+        CryptoFailed e -> fail (show e)
+        CryptoPassed a -> pure $ Ed448 a
+    _ -> fail "Unsupported `crv`"
+
+decodeECDSAPublicKey :: Decoder s ECDSAKey
+decodeECDSAPublicKey = do
+  algKey <- CBOR.decodeIntCanonical
+  when (algKey /= 3) $ fail "Expected required `alg`"
+  alg <- decodeCOSEAlgorithmIdentifier
+  hash <- case alg of
+    ECDSAIdentifier x -> pure x
+    _ -> fail "Unsupported `alg`"
+  crvKey <- CBOR.decodeIntCanonical
+  when (crvKey /= (-1)) $ fail "Expected required `crv`"
+  crv <- CBOR.decodeIntCanonical
+  curve <- case crv of
+    1 -> pure $ ECC.getCurveByName ECC.SEC_p256r1
+    2 -> pure $ ECC.getCurveByName ECC.SEC_p384r1
+    3 -> pure $ ECC.getCurveByName ECC.SEC_p521r1
+    _ -> fail "Unsupported `crv`"
+  xKey <- CBOR.decodeIntCanonical
+  when (xKey /= -2) $ fail "Expected required `x`"
+  x <- os2ip <$> CBOR.decodeBytesCanonical
+  yKey <- CBOR.decodeIntCanonical
+  when (yKey /= -3) $ fail "Expected required `x`"
+  tokenType <- CBOR.peekTokenType
+  y <- case tokenType of
+    -- TODO(arianvp): Implement compressed curve. Waiting for
+    -- https://github.com/haskell-crypto/cryptonite/issues/302
+    CBOR.TypeBool -> fail "Compressed format not supported _yet_ See Issue number X"
+    -- direct coordinate
+    CBOR.TypeBytes -> os2ip <$> CBOR.decodeBytesCanonical
+    _ -> fail "Unexpected token type"
+  let point = ECC.Point x y
+  when (not (ECC.isPointValid curve point)) $ fail "point not on curve"
+  pure $ ECDSAKey hash (ECDSA.PublicKey curve (ECC.Point x y))
+
+encodePublicKey :: PublicKey -> Encoding
+encodePublicKey (ECDSAPublicKey (ECDSAKey alg (ECDSA.PublicKey curve point))) =
+  CBOR.encodeMapLen 5
+    <> CBOR.encodeInt 1
+    <> CBOR.encodeInt 2
+    <> CBOR.encodeInt 3
+    <> encodeCOSEAlgorithmIdentifier (ECDSAIdentifier alg)
+    <> CBOR.encodeInt (-1)
+    <> CBOR.encodeInt
+      ( case curve of
+          curve | curve == ECC.getCurveByName ECC.SEC_p256r1 -> 1
+          curve | curve == ECC.getCurveByName ECC.SEC_p384r1 -> 2
+          curve | curve == ECC.getCurveByName ECC.SEC_p521r1 -> 3
+          _ | otherwise -> error "never happens"
+      )
+    <> ( case point of
+           ECC.Point x y ->
+             CBOR.encodeInt (-2)
+               <> CBOR.encodeBytes (i2osp x)
+               <> CBOR.encodeInt (-3)
+               <> CBOR.encodeBytes (i2osp y)
+           _ -> error "never happens"
+       )
+encodePublicKey (EdDSAPublicKey key) =
+  CBOR.encodeMapLen 4
+    <> CBOR.encodeInt 1
+    <> CBOR.encodeInt 1
+    <> CBOR.encodeInt 3
+    <> encodeCOSEAlgorithmIdentifier EdDSA
+    <> CBOR.encodeInt (-1)
+    <> case key of
+      Ed25519 key ->
+        CBOR.encodeInt 6
+          <> CBOR.encodeInt (-2)
+          <> CBOR.encodeBytes (ByteArray.convert key)
+      Ed448 key ->
+        CBOR.encodeInt 7
+          <> CBOR.encodeInt (-2)
+          <> CBOR.encodeBytes (ByteArray.convert key)
+
+encodeCOSEAlgorithmIdentifier :: COSEAlgorithmIdentifier -> Encoding
+encodeCOSEAlgorithmIdentifier x = CBOR.encodeInt $ case x of
+  ECDSAIdentifier ES256 -> (-7)
+  ECDSAIdentifier ES384 -> (-35)
+  ECDSAIdentifier ES512 -> (-36)
+  EdDSA -> (-8)
+
+-- | Decodes a signature for a specific public key's type
+-- Signatures are a bit weird in Webauthn.  For ES256 and RS256 they're ASN.1
+-- and for EdDSA they're COSE
+decodeECDSASignature :: ByteString -> Maybe ECDSA.Signature
+decodeECDSASignature sigbs =
+  case ASN1.decodeASN1' ASN1.BER sigbs of
+    Left _ -> Nothing
+    Right [ASN1.Start ASN1.Sequence, ASN1.IntVal r, ASN1.IntVal s, ASN1.End ASN1.Sequence] ->
+      Just (ECDSA.Signature r s)
+    Right _ -> Nothing
+
+verify :: PublicKey -> ByteString -> ByteString -> Bool
+verify key msg sig =
+  case key of
+    ECDSAPublicKey (ECDSAKey alg key) ->
+      case decodeECDSASignature sig of
+        Nothing -> False
+        Just sig ->
+          case alg of
+            ES256 -> ECDSA.verify Hash.SHA256 key sig msg
+            ES384 -> ECDSA.verify Hash.SHA384 key sig msg
+            ES512 -> ECDSA.verify Hash.SHA512 key sig msg
+    EdDSAPublicKey (Ed25519 key) ->
+      case Ed25519.signature sig of
+        CryptoPassed sig -> Ed25519.verify key msg sig
+        CryptoFailed _ -> False
+    EdDSAPublicKey (Ed448 key) ->
+      case Ed448.signature sig of
+        CryptoPassed sig -> Ed448.verify key msg sig
+        CryptoFailed _ -> False

--- a/fido/Crypto/Fido2/PublicKey.hs
+++ b/fido/Crypto/Fido2/PublicKey.hs
@@ -14,7 +14,6 @@ module Crypto.Fido2.PublicKey
     toCurve,
     verify,
     alg,
-    crv,
     curveForAlg,
   )
 where
@@ -94,9 +93,6 @@ data PublicKey
   = EdDSAPublicKey EdDSAKey
   | ECDSAPublicKey ECDSAKey
   deriving (Show, Eq)
-
-crv :: ECDSAKey -> CurveIdentifier
-crv (ECDSAKey alg _)  = curveForAlg alg
 
 alg :: ECDSAKey -> ECDSAIdentifier
 alg (ECDSAKey alg _) = alg
@@ -187,7 +183,7 @@ decodeECDSAPublicKey = do
     ECDSAIdentifier x -> pure x
     _ -> fail "Unsupported `alg`"
   decodeMapKey Crv
-  curve <- decodeCurveIdentifier
+  curve <- decode
   when (curve /= curveForAlg alg') $ fail "Curve must match alg. See <section>"
   decodeMapKey X
   x <- os2ip <$> CBOR.decodeBytesCanonical

--- a/fido/Crypto/Fido2/PublicKey.hs
+++ b/fido/Crypto/Fido2/PublicKey.hs
@@ -6,6 +6,7 @@
 -- | Include
 module Crypto.Fido2.PublicKey
   ( COSEAlgorithmIdentifier (..),
+    ECDSAIdentifier (..),
     PublicKey,
     decodePublicKey,
     encodePublicKey,

--- a/fido/Crypto/Fido2/PublicKey.hs
+++ b/fido/Crypto/Fido2/PublicKey.hs
@@ -15,6 +15,8 @@ module Crypto.Fido2.PublicKey
     encodePublicKey,
     toCurve,
     verify,
+    alg,
+    crv,
   )
 where
 
@@ -93,6 +95,12 @@ data PublicKey
   = EdDSAPublicKey EdDSAKey
   | ECDSAPublicKey ECDSAKey
   deriving (Show, Eq)
+
+crv :: ECDSAKey -> CurveIdentifier
+crv (ECDSAKey _ crv _)  = crv
+
+alg :: ECDSAKey -> ECDSAIdentifier
+alg (ECDSAKey alg _ _) = alg
 
 data KeyType = OKP | ECC
 

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -91,4 +91,6 @@ test-suite tests
     filepath,
     QuickCheck,
     hspec,
-    cborg
+    cborg,
+    cryptonite,
+    serialise

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -96,4 +96,7 @@ test-suite tests
     cborg,
     cborg-json,
     cryptonite,
-    serialise
+    serialise,
+    quickcheck-instances,
+    asn1-encoding,
+    memory

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -61,6 +61,7 @@ executable server
     aeson-qq,
     base64-bytestring,
     cborg,
+    serialise,
     bytestring,
     containers,
     cookie,

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -85,7 +85,9 @@ test-suite tests
   hs-source-dirs: tests
   main-is: Spec.hs
   other-modules:
-    PublicKeySpec
+    PublicKeySpec,
+    AttestationSpec,
+    Util
   build-depends:
     aeson,
     bytestring,
@@ -100,4 +102,5 @@ test-suite tests
     serialise,
     quickcheck-instances,
     asn1-encoding,
+    text,
     memory

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -83,6 +83,8 @@ test-suite tests
   type: exitcode-stdio-1.0
   hs-source-dirs: tests
   main-is: Spec.hs
+  other-modules:
+    PublicKeySpec
   build-depends:
     aeson,
     bytestring,
@@ -92,5 +94,6 @@ test-suite tests
     QuickCheck,
     hspec,
     cborg,
+    cborg-json,
     cryptonite,
     serialise

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -42,11 +42,13 @@ library
     unordered-containers,
     x509,
     scientific,
-    vector
+    vector,
+    QuickCheck
   exposed-modules:
     Crypto.Fido2.Assertion,
     Crypto.Fido2.Attestation,
     Crypto.Fido2.Protocol,
+    Crypto.Fido2.PublicKey
 
 executable server
   import: sanity
@@ -58,7 +60,7 @@ executable server
     aeson,
     aeson-qq,
     base64-bytestring,
-    binary,
+    cborg,
     bytestring,
     containers,
     cookie,
@@ -87,4 +89,6 @@ test-suite tests
     directory,
     fido2,
     filepath,
+    QuickCheck,
     hspec,
+    cborg

--- a/fido2.nix
+++ b/fido2.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, aeson-qq, asn1-encoding, base
 , base64-bytestring, binary, bytestring, cborg, containers, cookie
 , cryptonite, directory, filepath, hspec, http-types, memory, mtl
-, scientific, scotty, serialise, sqlite-simple, stdenv, stm, text
-, transformers, unordered-containers, uuid, vector, wai
+, QuickCheck, scientific, scotty, serialise, sqlite-simple, stdenv
+, stm, text, transformers, unordered-containers, uuid, vector, wai
 , wai-middleware-static, warp, x509
 }:
 mkDerivation {
@@ -13,16 +13,16 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson asn1-encoding base base64-bytestring binary bytestring cborg
-    containers cryptonite memory scientific serialise text
+    containers cryptonite memory QuickCheck scientific serialise text
     unordered-containers vector x509
   ];
   executableHaskellDepends = [
-    aeson aeson-qq base base64-bytestring binary bytestring containers
+    aeson aeson-qq base base64-bytestring bytestring cborg containers
     cookie cryptonite http-types mtl scotty sqlite-simple stm text
     transformers uuid wai wai-middleware-static warp
   ];
   testHaskellDepends = [
-    aeson base bytestring directory filepath hspec
+    aeson base bytestring cborg directory filepath hspec QuickCheck
   ];
   license = "unknown";
   hydraPlatforms = stdenv.lib.platforms.none;

--- a/fido2.nix
+++ b/fido2.nix
@@ -19,12 +19,13 @@ mkDerivation {
   ];
   executableHaskellDepends = [
     aeson aeson-qq base base64-bytestring bytestring cborg containers
-    cookie cryptonite http-types mtl scotty sqlite-simple stm text
-    transformers uuid wai wai-middleware-static warp
+    cookie cryptonite http-types mtl scotty serialise sqlite-simple stm
+    text transformers uuid wai wai-middleware-static warp
   ];
   testHaskellDepends = [
-    aeson base bytestring cborg cborg-json cryptonite directory
-    filepath hspec memory QuickCheck quickcheck-instances serialise
+    aeson asn1-encoding base bytestring cborg cborg-json cryptonite
+    directory filepath hspec memory QuickCheck quickcheck-instances
+    serialise
   ];
   license = "unknown";
   hydraPlatforms = stdenv.lib.platforms.none;

--- a/fido2.nix
+++ b/fido2.nix
@@ -25,7 +25,7 @@ mkDerivation {
   testHaskellDepends = [
     aeson asn1-encoding base bytestring cborg cborg-json cryptonite
     directory filepath hspec memory QuickCheck quickcheck-instances
-    serialise
+    serialise text
   ];
   license = "unknown";
   hydraPlatforms = stdenv.lib.platforms.none;

--- a/fido2.nix
+++ b/fido2.nix
@@ -22,7 +22,8 @@ mkDerivation {
     transformers uuid wai wai-middleware-static warp
   ];
   testHaskellDepends = [
-    aeson base bytestring cborg directory filepath hspec QuickCheck
+    aeson base bytestring cborg cryptonite directory filepath hspec
+    QuickCheck
   ];
   license = "unknown";
   hydraPlatforms = stdenv.lib.platforms.none;

--- a/fido2.nix
+++ b/fido2.nix
@@ -1,9 +1,10 @@
 { mkDerivation, aeson, aeson-qq, asn1-encoding, base
-, base64-bytestring, binary, bytestring, cborg, containers, cookie
-, cryptonite, directory, filepath, hspec, http-types, memory, mtl
-, QuickCheck, scientific, scotty, serialise, sqlite-simple, stdenv
-, stm, text, transformers, unordered-containers, uuid, vector, wai
-, wai-middleware-static, warp, x509
+, base64-bytestring, binary, bytestring, cborg, cborg-json
+, containers, cookie, cryptonite, directory, filepath, hspec
+, http-types, memory, mtl, QuickCheck, scientific, scotty
+, serialise, sqlite-simple, stdenv, stm, text, transformers
+, unordered-containers, uuid, vector, wai, wai-middleware-static
+, warp, x509
 }:
 mkDerivation {
   pname = "fido2";
@@ -22,8 +23,8 @@ mkDerivation {
     transformers uuid wai wai-middleware-static warp
   ];
   testHaskellDepends = [
-    aeson base bytestring cborg cryptonite directory filepath hspec
-    QuickCheck
+    aeson base bytestring cborg cborg-json cryptonite directory
+    filepath hspec QuickCheck serialise
   ];
   license = "unknown";
   hydraPlatforms = stdenv.lib.platforms.none;

--- a/fido2.nix
+++ b/fido2.nix
@@ -1,10 +1,10 @@
 { mkDerivation, aeson, aeson-qq, asn1-encoding, base
 , base64-bytestring, binary, bytestring, cborg, cborg-json
 , containers, cookie, cryptonite, directory, filepath, hspec
-, http-types, memory, mtl, QuickCheck, scientific, scotty
-, serialise, sqlite-simple, stdenv, stm, text, transformers
-, unordered-containers, uuid, vector, wai, wai-middleware-static
-, warp, x509
+, http-types, memory, mtl, QuickCheck, quickcheck-instances
+, scientific, scotty, serialise, sqlite-simple, stdenv, stm, text
+, transformers, unordered-containers, uuid, vector, wai
+, wai-middleware-static, warp, x509
 }:
 mkDerivation {
   pname = "fido2";
@@ -24,7 +24,7 @@ mkDerivation {
   ];
   testHaskellDepends = [
     aeson base bytestring cborg cborg-json cryptonite directory
-    filepath hspec QuickCheck serialise
+    filepath hspec memory QuickCheck quickcheck-instances serialise
   ];
   license = "unknown";
   hydraPlatforms = stdenv.lib.platforms.none;

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,3 +1,17 @@
 cradle:
-  cabal:
-    component: lib:fido2
+  multi:
+  - path: "./fido"
+    config:
+      cradle:
+        cabal:
+          component: lib:fido2
+  - path: "./server"
+    config:
+      cradle:
+        cabal:
+          component: exe:server
+  - path: "./tests"
+    config:
+      cradle:
+        cabal:
+          component: test:tests

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -16,6 +16,7 @@ where
 
 import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Write as CBOR
+import qualified Codec.Serialise as Serialise
 import qualified Crypto.Fido2.Assertion as Assertion
 import Crypto.Fido2.Protocol
   ( CredentialId (CredentialId),
@@ -112,7 +113,7 @@ addAttestedCredentialData
       \ (?, ?, ?, ?);                                               "
       ( credentialId,
         userId,
-        CBOR.toStrictByteString (Fido2.encodePublicKey publicKey)
+        CBOR.toStrictByteString (Serialise.encode publicKey)
       )
 
 getUserByCredentialId :: Transaction -> Fido2.CredentialId -> IO (Maybe Fido2.UserId)
@@ -141,7 +142,7 @@ getCredentialsByUserId (Transaction conn) (UserId (URLEncodedBase64 userId)) = d
     mkCredential (id, publicKey) = do
       -- TODO(#22): Convert to the compressed representation so we don't need
       --  the Maybe.
-      case snd <$> CBOR.deserialiseFromBytes Fido2.decodePublicKey publicKey of
+      case snd <$> CBOR.deserialiseFromBytes Serialise.decode publicKey of
         Left _ -> Nothing
         Right publicKey ->
           pure $

--- a/server/Database.hs
+++ b/server/Database.hs
@@ -14,6 +14,8 @@ module Database
   )
 where
 
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Write as CBOR
 import qualified Crypto.Fido2.Assertion as Assertion
 import Crypto.Fido2.Protocol
   ( CredentialId (CredentialId),
@@ -21,7 +23,7 @@ import Crypto.Fido2.Protocol
     UserId (UserId),
   )
 import qualified Crypto.Fido2.Protocol as Fido2
-import qualified Data.Binary as Binary
+import qualified Crypto.Fido2.PublicKey as Fido2
 import qualified Data.Maybe as Maybe
 import qualified Database.SQLite.Simple as Sqlite
 
@@ -52,8 +54,7 @@ initialize conn = do
     " create table if not exists attested_credential_data                      \
     \ ( id               blob    primary key                                   \
     \ , user_id          blob    not null                                      \
-    \ , public_key_x     blob    not null                                      \
-    \ , public_key_y     blob    not null                                      \
+    \ , public_key       blob    not null                                      \
     \ , created          text    not null                                      \
     \                    default (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))       \
     \ , foreign key (user_id) references users (id)                            \
@@ -106,13 +107,12 @@ addAttestedCredentialData
     Sqlite.execute
       conn
       " insert into attested_credential_data                        \
-      \ (id, user_id, public_key_x, public_key_y)                   \
+      \ (id, user_id, public_key)                                   \
       \ values                                                      \
       \ (?, ?, ?, ?);                                               "
       ( credentialId,
         userId,
-        Binary.encode $ Fido2.publicKeyX publicKey,
-        Binary.encode $ Fido2.publicKeyY publicKey
+        CBOR.toStrictByteString (Fido2.encodePublicKey publicKey)
       )
 
 getUserByCredentialId :: Transaction -> Fido2.CredentialId -> IO (Maybe Fido2.UserId)
@@ -134,19 +134,21 @@ getCredentialsByUserId (Transaction conn) (UserId (URLEncodedBase64 userId)) = d
   credentialRows <-
     Sqlite.query
       conn
-      "select id, public_key_x, public_key_y from attested_credential_data where user_id = ?;"
+      "select id, public_key from attested_credential_data where user_id = ?;"
       [userId]
   pure $ Maybe.catMaybes $ fmap (mkCredential) $ credentialRows
   where
-    mkCredential (id, x, y) = do
+    mkCredential (id, publicKey) = do
       -- TODO(#22): Convert to the compressed representation so we don't need
       --  the Maybe.
-      publicKey <- Fido2.mkEcdsaPublicKey (Binary.decode x) (Binary.decode y)
-      pure $
-        Assertion.Credential
-          { id = CredentialId $ URLEncodedBase64 id,
-            publicKey = publicKey
-          }
+      case snd <$> CBOR.deserialiseFromBytes Fido2.decodePublicKey publicKey of
+        Left _ -> Nothing
+        Right publicKey ->
+          pure $
+            Assertion.Credential
+              { id = CredentialId $ URLEncodedBase64 id,
+                publicKey = publicKey
+              }
 
 getCredentialIdsByUserId :: Transaction -> Fido2.UserId -> IO [Fido2.CredentialId]
 getCredentialIdsByUserId (Transaction conn) (UserId (URLEncodedBase64 userId)) = do

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -18,6 +18,7 @@ import Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT))
 import qualified Crypto.Fido2.Assertion as Assertion
 import Crypto.Fido2.Attestation (Error, verifyAttestationResponse)
 import qualified Crypto.Fido2.Protocol as Fido2
+import qualified Crypto.Fido2.PublicKey as Fido2
 import Data.Aeson (FromJSON)
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
@@ -310,7 +311,7 @@ defaultPkcco userEntity challenge =
       user = userEntity,
       challenge = challenge,
       -- Empty credentialparameters are not supported.
-      pubKeyCredParams = [Fido2.PublicKeyCredentialParameters {typ = Fido2.PublicKey, alg = Fido2.ES256}],
+      pubKeyCredParams = [Fido2.PublicKeyCredentialParameters {typ = Fido2.PublicKey, alg = Fido2.ECDSAIdentifier Fido2.ES256}],
       timeout = Nothing,
       excludeCredentials = Nothing,
       authenticatorSelection =

--- a/tests/AttestationSpec.hs
+++ b/tests/AttestationSpec.hs
@@ -1,0 +1,7 @@
+module AttestationSpec (spec) where
+
+import Test.Hspec (SpecWith, describe, it, shouldSatisfy)
+
+spec :: SpecWith ()
+spec = do
+  undefined

--- a/tests/PublicKeySpec.hs
+++ b/tests/PublicKeySpec.hs
@@ -23,7 +23,6 @@ import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
 import qualified Crypto.PubKey.ECC.Generate as ECC
 import qualified Crypto.PubKey.ECC.Types as ECC
 import qualified Crypto.PubKey.Ed25519 as Ed25519
-import qualified Crypto.PubKey.Ed448 as Ed448
 import qualified Crypto.Random as Random
 import qualified Data.ASN1.BinaryEncoding as ASN1
 import qualified Data.ASN1.Encoding as ASN1
@@ -31,9 +30,9 @@ import qualified Data.ASN1.Prim as ASN1
 import qualified Data.Aeson as Aeson
 import Data.ByteArray (convert)
 import Data.ByteString (ByteString)
-import Test.Hspec
-import Test.QuickCheck (counterexample, (===), (==>), Arbitrary, Gen, arbitrary, elements, frequency, oneof, property)
-import Test.QuickCheck.Instances.ByteString
+import Test.Hspec(shouldSatisfy, describe, it, SpecWith)
+import Test.QuickCheck ((==>), Arbitrary, Gen, arbitrary, counterexample, elements, frequency, oneof, property)
+import Test.QuickCheck.Instances.ByteString()
 
 instance Arbitrary ECDSAIdentifier where
   arbitrary = elements [ES256, ES384, ES512]
@@ -73,10 +72,10 @@ privateKey :: ECDSAKeyPair -> ECDSA.PrivateKey
 privateKey (ECDSAKeyPair (_, (_, priv))) = priv
 
 getPublicKey :: ECDSAIdentifier -> ECDSAKeyPair -> PublicKey
-getPublicKey alg (ECDSAKeyPair (crv, (pub, priv))) = ECDSAPublicKey $ ECDSAKey alg crv (ECDSA.public_q pub)
+getPublicKey alg (ECDSAKeyPair (crv, (pub, _))) = ECDSAPublicKey $ ECDSAKey alg crv (ECDSA.public_q pub)
 
 getPoint :: ECDSAKeyPair -> (CurveIdentifier, ECC.Point)
-getPoint (ECDSAKeyPair (ident, (pub, priv))) = (ident, ECDSA.public_q pub)
+getPoint (ECDSAKeyPair (ident, (pub, _))) = (ident, ECDSA.public_q pub)
 
 instance Arbitrary ECDSAKeyPair where
   arbitrary = ECDSAKeyPair <$> randomECDSAKey

--- a/tests/PublicKeySpec.hs
+++ b/tests/PublicKeySpec.hs
@@ -4,10 +4,7 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module PublicKeySpec
-  ( spec,
-  )
-where
+module PublicKeySpec (spec) where
 
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.FlatTerm as FlatTerm
@@ -15,7 +12,6 @@ import qualified Codec.CBOR.JSON as JSON
 import qualified Codec.CBOR.Read as Read
 import qualified Codec.CBOR.Write as Write
 import qualified Codec.Serialise as Serialise
-import qualified Codec.Serialise.Properties as Serialise.Properties
 import Crypto.Fido2.PublicKey
 import Crypto.Hash (SHA384 (SHA384))
 import Crypto.Hash.Algorithms (SHA256 (SHA256))
@@ -35,6 +31,7 @@ import Data.Either (isLeft)
 import Test.Hspec (SpecWith, describe, it, shouldSatisfy)
 import Test.QuickCheck ((.&&.), (===), (==>), Arbitrary, Gen, arbitrary, counterexample, elements, frequency, oneof, property, total)
 import Test.QuickCheck.Instances.ByteString ()
+import Util (roundtrips)
 
 instance Arbitrary CurveIdentifier where
   arbitrary = elements [P256, P384, P521]
@@ -87,14 +84,6 @@ randomECDSAKey = do
 
 spec :: SpecWith ()
 spec = do
-  let roundtrips :: forall a. (Eq a, Show a, Serialise.Serialise a, Arbitrary a) => SpecWith ()
-      roundtrips = do
-        it "serialiseIdentity" $ property $ \(key :: a) ->
-          Serialise.Properties.serialiseIdentity key
-        it "flatTermIdentity" $ property $ \(key :: a) ->
-          Serialise.Properties.flatTermIdentity key
-        it "hasValidFlatTerm" $ property $ \(key :: a) ->
-          Serialise.Properties.hasValidFlatTerm key
   describe "PublicKey" $ do
     roundtrips @PublicKey
     describe "EdDSA" $ do

--- a/tests/PublicKeySpec.hs
+++ b/tests/PublicKeySpec.hs
@@ -4,7 +4,10 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module PublicKeySpec (spec) where
+module PublicKeySpec
+  ( spec,
+  )
+where
 
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.FlatTerm as FlatTerm

--- a/tests/PublicKeySpec.hs
+++ b/tests/PublicKeySpec.hs
@@ -33,7 +33,7 @@ import Data.ByteArray (convert)
 import Data.ByteString (ByteString)
 import Data.Either (isLeft)
 import Test.Hspec (SpecWith, describe, it, shouldSatisfy)
-import Test.QuickCheck ((===), (==>), Arbitrary, Gen, arbitrary, counterexample, elements, frequency, oneof, property)
+import Test.QuickCheck ((.&&.), (===), (==>), Arbitrary, Gen, arbitrary, counterexample, elements, frequency, oneof, property, total)
 import Test.QuickCheck.Instances.ByteString ()
 
 instance Arbitrary CurveIdentifier where
@@ -134,7 +134,9 @@ spec = do
           (map : ktyKey : ktyVal : algKey : algVal : crvKey : crvVal : xs) ->
             crvVal /= crv
               ==> let key' = map : ktyKey : ktyVal : algKey : algVal : crvKey : crv : xs
-                   in isLeft (FlatTerm.fromFlatTerm (Serialise.decode @PublicKey) key')
+                      decoded = FlatTerm.fromFlatTerm (Serialise.decode @PublicKey) key'
+                   in case decoded of
+                        Left x -> total x
           _ -> error "Didnt match shape"
   describe "COSEAlgorithmIdentifier" $ do
     roundtrips @COSEAlgorithmIdentifier

--- a/tests/PublicKeySpec.hs
+++ b/tests/PublicKeySpec.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module PublicKeySpec (spec) where
+
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Write as Write
+import qualified Codec.Serialise as Serialise
+import Crypto.Fido2.PublicKey
+import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
+import qualified Crypto.PubKey.ECC.Generate as ECC
+import qualified Crypto.PubKey.ECC.Types as ECC
+import qualified Crypto.PubKey.Ed25519 as Ed25519
+import qualified Crypto.PubKey.Ed448 as Ed448
+import qualified Crypto.Random as Random
+import Test.Hspec
+import Test.QuickCheck ((===), Arbitrary, Gen, arbitrary, elements, oneof, property)
+import Data.Either (isLeft)
+
+instance Arbitrary ECDSAIdentifier where
+  arbitrary = elements [ES256, ES384, ES512]
+
+instance Arbitrary COSEAlgorithmIdentifier where
+  arbitrary = oneof [pure EdDSA, arbitrary]
+
+instance Arbitrary EdDSAKey where
+  arbitrary =
+    oneof
+      [ Ed25519 <$> randomEd25519PublicKey,
+        Ed448 <$> randomEd448PublicKey
+      ]
+
+instance Arbitrary ECDSAKey where
+  arbitrary =
+    oneof
+      [ uncurry (ECDSAKey ES256) <$> randomECDSAPublicKey,
+        uncurry (ECDSAKey ES384) <$> randomECDSAPublicKey,
+        uncurry (ECDSAKey ES512) <$> randomECDSAPublicKey
+      ]
+
+instance Arbitrary CurveIdentifier where
+  arbitrary = elements [P256, P384, P521]
+
+instance Arbitrary PublicKey where
+  arbitrary = oneof [EdDSAPublicKey <$> arbitrary, ECDSAPublicKey <$> arbitrary]
+
+randomEd25519PublicKey :: Gen Ed25519.PublicKey
+randomEd25519PublicKey = do
+  rng <- Random.drgNewSeed . Random.seedFromInteger <$> arbitrary
+  let (a, _) = Random.withDRG rng (Ed25519.toPublic <$> Ed25519.generateSecretKey)
+  pure a
+
+randomEd448PublicKey :: Gen Ed448.PublicKey
+randomEd448PublicKey = do
+  rng <- Random.drgNewSeed . Random.seedFromInteger <$> arbitrary
+  let (a, _) = Random.withDRG rng (Ed448.toPublic <$> Ed448.generateSecretKey)
+  pure a
+
+randomECDSAPublicKey :: Gen (CurveIdentifier, ECC.Point)
+randomECDSAPublicKey = do
+  curveIdentifier <- arbitrary
+  let curve = toCurve curveIdentifier
+  rng <- Random.drgNewSeed . Random.seedFromInteger <$> arbitrary
+  let ((ECDSA.PublicKey _ point, _), _) = Random.withDRG rng (ECC.generate curve)
+  pure (curveIdentifier, point)
+
+spec :: SpecWith ()
+spec = do
+  it "roundtrips" $ do
+    property $ \(key :: PublicKey) -> do
+      let bs = Serialise.serialise key
+      let rs = Serialise.deserialiseOrFail bs
+      rs === pure key
+  it "fails to decode unspported COSEAlgorithmIdentifiers" $  do
+    let bs = Write.toLazyByteString (CBOR.encodeInt (-300))
+    Serialise.deserialiseOrFail @COSEAlgorithmIdentifier bs `shouldSatisfy` isLeft

--- a/tests/PublicKeySpec.hs
+++ b/tests/PublicKeySpec.hs
@@ -41,11 +41,8 @@ instance Arbitrary COSEAlgorithmIdentifier where
   arbitrary = frequency [(1, pure EdDSA), (3, ECDSAIdentifier <$> arbitrary)]
 
 instance Arbitrary EdDSAKey where
-  arbitrary =
-    oneof
-      [ Ed25519 . Ed25519.toPublic <$> randomEd25519Key,
-        Ed448 . Ed448.toPublic <$> randomEd448Key
-      ]
+  arbitrary = Ed25519 . Ed25519.toPublic <$> randomEd25519Key
+     
 
 instance Arbitrary ECDSAKey where
   arbitrary =
@@ -68,12 +65,6 @@ randomEd25519Key :: Gen Ed25519.SecretKey
 randomEd25519Key = do
   rng <- Random.drgNewSeed . Random.seedFromInteger <$> arbitrary
   let (a, _) = Random.withDRG rng Ed25519.generateSecretKey
-  pure a
-
-randomEd448Key :: Gen Ed448.SecretKey
-randomEd448Key = do
-  rng <- Random.drgNewSeed . Random.seedFromInteger <$> arbitrary
-  let (a, _) = Random.withDRG rng Ed448.generateSecretKey
   pure a
 
 newtype ECDSAKeyPair = ECDSAKeyPair (CurveIdentifier, (ECDSA.PublicKey, ECDSA.PrivateKey)) deriving (Eq, Show)

--- a/tests/PublicKeySpec.hs
+++ b/tests/PublicKeySpec.hs
@@ -1,43 +1,58 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-module PublicKeySpec (spec) where
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module PublicKeySpec
+  ( spec,
+  )
+where
 
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.JSON as JSON
-import qualified Codec.CBOR.Write as Write
 import qualified Codec.CBOR.Read as Read
-import qualified Data.Aeson as Aeson
+import qualified Codec.CBOR.Write as Write
 import qualified Codec.Serialise as Serialise
+import qualified Codec.Serialise.Properties as Serialise.Properties
 import Crypto.Fido2.PublicKey
+import Crypto.Hash (SHA384 (SHA384))
+import Crypto.Hash.Algorithms (SHA256 (SHA256))
+import Crypto.Hash.Algorithms (SHA512 (SHA512))
 import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
 import qualified Crypto.PubKey.ECC.Generate as ECC
 import qualified Crypto.PubKey.ECC.Types as ECC
 import qualified Crypto.PubKey.Ed25519 as Ed25519
 import qualified Crypto.PubKey.Ed448 as Ed448
 import qualified Crypto.Random as Random
+import qualified Data.ASN1.BinaryEncoding as ASN1
+import qualified Data.ASN1.Encoding as ASN1
+import qualified Data.ASN1.Prim as ASN1
+import qualified Data.Aeson as Aeson
+import Data.ByteArray (convert)
+import Data.ByteString (ByteString)
 import Test.Hspec
-import Test.QuickCheck ((===), Arbitrary, Gen, frequency, arbitrary, elements, oneof, property)
-import Data.Either (isLeft)
+import Test.QuickCheck ((===), Arbitrary, Gen, arbitrary, elements, frequency, oneof, property)
+import Test.QuickCheck.Instances.ByteString
 
 instance Arbitrary ECDSAIdentifier where
   arbitrary = elements [ES256, ES384, ES512]
 
 instance Arbitrary COSEAlgorithmIdentifier where
-  arbitrary = frequency  [(1, pure EdDSA), (3, ECDSAIdentifier <$> arbitrary)]
+  arbitrary = frequency [(1, pure EdDSA), (3, ECDSAIdentifier <$> arbitrary)]
 
 instance Arbitrary EdDSAKey where
   arbitrary =
     oneof
-      [ Ed25519 <$> randomEd25519PublicKey,
-        Ed448 <$> randomEd448PublicKey
+      [ Ed25519 . Ed25519.toPublic <$> randomEd25519Key,
+        Ed448 . Ed448.toPublic <$> randomEd448Key
       ]
 
 instance Arbitrary ECDSAKey where
   arbitrary =
     oneof
-      [ uncurry (ECDSAKey ES256) <$> randomECDSAPublicKey,
-        uncurry (ECDSAKey ES384) <$> randomECDSAPublicKey,
-        uncurry (ECDSAKey ES512) <$> randomECDSAPublicKey
+      [ uncurry (ECDSAKey ES256) . getPoint <$> arbitrary,
+        uncurry (ECDSAKey ES384) . getPoint <$> arbitrary,
+        uncurry (ECDSAKey ES512) . getPoint <$> arbitrary
       ]
 
 instance Arbitrary CurveIdentifier where
@@ -46,46 +61,94 @@ instance Arbitrary CurveIdentifier where
 instance Arbitrary PublicKey where
   arbitrary = oneof [EdDSAPublicKey <$> arbitrary, ECDSAPublicKey <$> arbitrary]
 
-randomEd25519PublicKey :: Gen Ed25519.PublicKey
-randomEd25519PublicKey = do
+instance Arbitrary Ed25519.SecretKey where
+  arbitrary = randomEd25519Key
+
+randomEd25519Key :: Gen Ed25519.SecretKey
+randomEd25519Key = do
   rng <- Random.drgNewSeed . Random.seedFromInteger <$> arbitrary
-  let (a, _) = Random.withDRG rng (Ed25519.toPublic <$> Ed25519.generateSecretKey)
+  let (a, _) = Random.withDRG rng Ed25519.generateSecretKey
   pure a
 
-randomEd448PublicKey :: Gen Ed448.PublicKey
-randomEd448PublicKey = do
+randomEd448Key :: Gen Ed448.SecretKey
+randomEd448Key = do
   rng <- Random.drgNewSeed . Random.seedFromInteger <$> arbitrary
-  let (a, _) = Random.withDRG rng (Ed448.toPublic <$> Ed448.generateSecretKey)
+  let (a, _) = Random.withDRG rng Ed448.generateSecretKey
   pure a
 
-randomECDSAPublicKey :: Gen (CurveIdentifier, ECC.Point)
-randomECDSAPublicKey = do
+newtype ECDSAKeyPair = ECDSAKeyPair (CurveIdentifier, (ECDSA.PublicKey, ECDSA.PrivateKey)) deriving (Eq, Show)
+
+privateKey :: ECDSAKeyPair -> ECDSA.PrivateKey
+privateKey (ECDSAKeyPair (_, (_, priv))) = priv
+
+getPublicKey :: ECDSAIdentifier -> ECDSAKeyPair -> PublicKey
+getPublicKey alg (ECDSAKeyPair (crv, (pub, priv))) = ECDSAPublicKey $ ECDSAKey alg crv (ECDSA.public_q pub)
+
+getPoint :: ECDSAKeyPair -> (CurveIdentifier, ECC.Point)
+getPoint (ECDSAKeyPair (ident, (pub, priv))) = (ident, ECDSA.public_q pub)
+
+instance Arbitrary ECDSAKeyPair where
+  arbitrary = ECDSAKeyPair <$> randomECDSAKey
+
+randomECDSAKey :: Gen (CurveIdentifier, (ECDSA.PublicKey, ECDSA.PrivateKey))
+randomECDSAKey = do
   curveIdentifier <- arbitrary
   let curve = toCurve curveIdentifier
   rng <- Random.drgNewSeed . Random.seedFromInteger <$> arbitrary
-  let ((ECDSA.PublicKey _ point, _), _) = Random.withDRG rng (ECC.generate curve)
-  pure (curveIdentifier, point)
+  let (x, _) = Random.withDRG rng (ECC.generate curve)
+  pure (curveIdentifier, x)
 
 spec :: SpecWith ()
 spec = do
-  it "roundtrips" $ do
-    property $ \(key :: PublicKey) -> do
-      let bs = Serialise.serialise key
-      let rs = Serialise.deserialiseOrFail bs
-      rs === pure key
-  it "fails to decode unspported COSEAlgorithmIdentifiers" $  do
-    let bs = Write.toLazyByteString (CBOR.encodeInt (-300))
-    Serialise.deserialiseOrFail @COSEAlgorithmIdentifier bs `shouldSatisfy` isLeft
-
-  it "can encode COSEAlgorithmIdentifier as JSON" $ do
-    property $ \(alg :: COSEAlgorithmIdentifier) ->
-      let
-        bs = Serialise.serialise alg
-        rs = Read.deserialiseFromBytes (JSON.decodeValue False) bs
-        alg' = Aeson.toJSON alg
-      in
-        pure (Aeson.toJSON alg) == (snd <$> rs)
-
-
-
-
+  let roundtrips :: forall a. (Eq a, Show a, Serialise.Serialise a, Arbitrary a) => SpecWith ()
+      roundtrips = do
+        it "serialiseIdentity" $ property $ \(key :: a) ->
+          Serialise.Properties.serialiseIdentity key
+        it "flatTermIdentity" $ property $ \(key :: a) ->
+          Serialise.Properties.flatTermIdentity key
+        it "hasValidFlatTerm" $ property $ \(key :: a) ->
+          Serialise.Properties.hasValidFlatTerm key
+  describe "PublicKey" $ do
+    roundtrips @PublicKey
+    describe "EdDSA" $ do
+      it "accepts valid signatures"
+        $ property
+        $ \(secret :: Ed25519.SecretKey, bytes :: ByteString) ->
+          let pub = Ed25519.toPublic secret
+              sig = Ed25519.sign secret pub bytes
+           in verify (EdDSAPublicKey (Ed25519 pub)) bytes (convert sig)
+    describe "ECDSA" $ do
+      it "accepts valid signatures"
+        $ property
+        $ \(keyPair :: ECDSAKeyPair, bytes :: ByteString, alg :: ECDSAIdentifier, seed :: Integer) ->
+          let drg = Random.drgNewSeed . Random.seedFromInteger $ seed
+              (ECDSA.Signature r s, _) = case alg of
+                ES256 -> Random.withDRG drg $ ECDSA.sign (privateKey keyPair) SHA256 bytes
+                ES384 -> Random.withDRG drg $ ECDSA.sign (privateKey keyPair) SHA384 bytes
+                ES512 -> Random.withDRG drg $ ECDSA.sign (privateKey keyPair) SHA512 bytes
+           in verify (getPublicKey alg keyPair) bytes (ASN1.encodeASN1' ASN1.DER [ASN1.Start ASN1.Sequence, ASN1.IntVal r, ASN1.IntVal s, ASN1.End ASN1.Sequence])
+      it "rejects invalid signatures"
+        $ property
+        $ \(keyPair :: ECDSAKeyPair, bytes :: ByteString, alg :: ECDSAIdentifier, r, s) ->
+          not
+            $ verify (getPublicKey alg keyPair) bytes
+            $ ASN1.encodeASN1' ASN1.DER [ASN1.Start ASN1.Sequence, ASN1.IntVal r, ASN1.IntVal s, ASN1.End ASN1.Sequence]
+      it "rejects invalid ASN.1"
+        $ property
+        $ \(keyPair :: ECDSAKeyPair, bytes :: ByteString, alg :: ECDSAIdentifier, r, s) ->
+          not
+            $ verify (getPublicKey alg keyPair) bytes
+            $ ASN1.encodeASN1' ASN1.DER [ASN1.Start ASN1.Sequence, ASN1.IntVal r, ASN1.IntVal s]
+  describe "COSEAlgorithmIdentifier" $ do
+    roundtrips @COSEAlgorithmIdentifier
+    it "fails to decode unspported COSEAlgorithmIdentifiers" $ do
+      let bs = Write.toLazyByteString (CBOR.encodeInt (-300))
+      Serialise.deserialiseOrFail @COSEAlgorithmIdentifier bs `shouldSatisfy` \x ->
+        case x of
+          Left (Read.DeserialiseFailure _ "Unsupported `alg`") -> True
+          _ -> False
+    it "can encode COSEAlgorithmIdentifier as JSON" $ do
+      property $ \(alg :: COSEAlgorithmIdentifier) ->
+        let bs = Serialise.serialise alg
+            rs = Read.deserialiseFromBytes (JSON.decodeValue False) bs
+         in pure (Aeson.toJSON alg) == (snd <$> rs)

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -9,12 +9,9 @@ module Main
   )
 where
 
-import qualified Codec.CBOR.Read as CBOR
-import qualified Codec.CBOR.Write as CBOR
 import qualified Crypto.Fido2.Assertion as Fido2
 import qualified Crypto.Fido2.Attestation as Fido2
 import qualified Crypto.Fido2.Protocol as Fido2
-import qualified Crypto.Fido2.PublicKey as PublicKey
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as ByteString
@@ -22,11 +19,11 @@ import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Either (isRight)
 import Data.Foldable (for_)
 import GHC.Stack (HasCallStack)
+import qualified PublicKeySpec
 import qualified System.Directory as Directory
 import System.FilePath ((</>))
 import Test.Hspec (Spec, describe, it, shouldSatisfy)
 import qualified Test.Hspec as Hspec
-import Test.QuickCheck (property)
 
 -- Load all files in the given directory, and ensure that all of them can be
 -- decoded. The caller can pass in a function to run further checks on the
@@ -57,12 +54,7 @@ main = Hspec.hspec $ do
       @(Fido2.PublicKeyCredential Fido2.AuthenticatorAssertionResponse)
       "tests/fixtures/login-complete"
       ignoreDecodedValue
-  describe "PublicKey" $ do
-    it "roundtrips" $ do
-      property $ \key -> do
-        let bs = CBOR.toLazyByteString (PublicKey.encodePublicKey key)
-        let rs = snd <$> CBOR.deserialiseFromBytes PublicKey.decodePublicKey bs
-        rs == pure key
+  describe "PublicKey" $ PublicKeySpec.spec
   describe "Attestation"
     $ it "tests whether the fixed register and login responses are matching"
     $ do

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -3,27 +3,42 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main
   ( main,
   )
 where
 
+import qualified AttestationSpec
+import Codec.CBOR.Term (Term (TInt))
 import qualified Crypto.Fido2.Assertion as Fido2
 import qualified Crypto.Fido2.Attestation as Fido2
+import qualified Crypto.Fido2.Attestation as Fido2Attestation
 import qualified Crypto.Fido2.Protocol as Fido2
+import qualified Crypto.Hash as Hash
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as ByteString
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LazyByteString
+import Data.Coerce (coerce)
 import Data.Either (isRight)
 import Data.Foldable (for_)
+import Data.Maybe (isNothing)
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
 import GHC.Stack (HasCallStack)
 import qualified PublicKeySpec
 import qualified System.Directory as Directory
 import System.FilePath ((</>))
-import Test.Hspec (Spec, describe, it, shouldSatisfy)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 import qualified Test.Hspec as Hspec
+import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary))
+import Test.QuickCheck.Gen (elements, listOf, oneof)
+import Test.QuickCheck.Instances.Text ()
+import Test.QuickCheck.Property ((===), (==>), property, total)
 
 -- Load all files in the given directory, and ensure that all of them can be
 -- decoded. The caller can pass in a function to run further checks on the
@@ -42,6 +57,70 @@ canDecodeAll path inspect = do
 ignoreDecodedValue :: a -> IO ()
 ignoreDecodedValue _ = pure ()
 
+instance Arbitrary Fido2.AuthenticatorAttestationResponse where
+  arbitrary = Fido2.AuthenticatorAttestationResponse <$> arbitrary <*> arbitrary
+
+instance Arbitrary Fido2.ClientData where
+  arbitrary =
+    Fido2.ClientData
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> pure undefined -- TODO: How to generate sha256?
+
+instance Arbitrary Fido2.AttestationObject where
+  arbitrary = Fido2.AttestationObject <$> arbitrary <*> pure "none" <*> pure []
+
+instance Arbitrary Fido2.AuthenticatorData where
+  arbitrary =
+    Fido2.AuthenticatorData
+      <$> pure undefined
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+
+instance Arbitrary Fido2Attestation.Error where
+  arbitrary =
+    elements
+      [ Fido2.InvalidWebauthnType,
+        Fido2.ChallengeDidNotMatch,
+        Fido2Attestation.RpIdMismatch,
+        Fido2Attestation.UserNotPresent,
+        Fido2Attestation.UserNotVerified,
+        Fido2.UnsupportedAttestationFormat,
+        Fido2.InvalidAttestationStatement,
+        Fido2.NoAttestedCredentialDataFound,
+        Fido2.NotTrustworthy
+      ]
+
+instance Arbitrary Fido2.CredentialId where
+  arbitrary = coerce (arbitrary @ByteString)
+
+instance Arbitrary Fido2.RpId where
+  arbitrary = coerce (arbitrary @Text)
+
+instance Arbitrary Fido2.UserVerificationRequirement where
+  arbitrary = elements [Fido2.UserVerificationDiscouraged, Fido2.UserVerificationPreferred, Fido2.UserVerificationRequired]
+
+instance Arbitrary Fido2.AttestedCredentialData where
+  arbitrary = Fido2.AttestedCredentialData <$> arbitrary <*> arbitrary <*> arbitrary
+
+instance Arbitrary Fido2.WebauthnType where
+  arbitrary = elements [Fido2.Get, Fido2.Create]
+
+instance Arbitrary Fido2.Challenge where
+  arbitrary = coerce (arbitrary @ByteString)
+
+instance Arbitrary Fido2.Origin where
+  arbitrary = coerce (arbitrary @Text)
+
+newtype RandomAttStmt = RandomAttStmt [(Term, Term)] deriving (Show)
+
+instance Arbitrary RandomAttStmt where
+  arbitrary = RandomAttStmt <$> listOf ((,) <$> (TInt <$> arbitrary) <*> (TInt <$> arbitrary))
+
 main :: IO ()
 main = Hspec.hspec $ do
   describe "AuthenticatorAttestationResponse" $
@@ -55,7 +134,240 @@ main = Hspec.hspec $ do
       "tests/fixtures/login-complete"
       ignoreDecodedValue
   describe "PublicKey" $ PublicKeySpec.spec
-  describe "Attestation"
+  describe "Attestation" $ do
+    it "fails if type is wrong" $
+      let resp =
+            Fido2.AuthenticatorAttestationResponse
+              { Fido2.clientData =
+                  Fido2.ClientData
+                    { Fido2.typ = Fido2.Get,
+                      Fido2.challenge = undefined,
+                      Fido2.origin = undefined,
+                      Fido2.clientDataHash = undefined
+                    },
+                Fido2.attestationObject = undefined
+              }
+       in case Fido2.verifyAttestationResponse undefined undefined undefined undefined resp of
+            Left x -> x `shouldBe` Fido2.InvalidWebauthnType
+    it "fails if challenges do not match" $ property $
+      \( coerce @ByteString -> c1,
+         coerce @ByteString -> c2,
+         clientData,
+         origin,
+         rp,
+         req,
+         resp'
+         ) ->
+          -- TODO: Do not expose Challenge; but use its MonadRandom instance ... ?
+          c1 /= c2
+            ==> let resp =
+                      (resp' :: Fido2.AuthenticatorAttestationResponse)
+                        { Fido2.clientData = clientData {Fido2.typ = Fido2.Create, Fido2.challenge = c1}
+                        }
+                 in case Fido2.verifyAttestationResponse origin rp c2 req resp of
+                      Left x -> x === Fido2.ChallengeDidNotMatch
+    it "fails if origins do not match" $ property $
+      \( c1 :: ByteString,
+         coerce @Text -> origin1,
+         coerce @Text -> origin2,
+         resp' :: Fido2.AuthenticatorAttestationResponse,
+         clientData :: Fido2.ClientData,
+         rp,
+         req
+         ) ->
+          origin1 /= origin2
+            ==> let resp =
+                      (resp' :: Fido2.AuthenticatorAttestationResponse)
+                        { Fido2.clientData =
+                            clientData
+                              { Fido2.typ = Fido2.Create,
+                                Fido2.challenge = coerce c1,
+                                Fido2.origin = origin1
+                              }
+                        }
+                 in case Fido2.verifyAttestationResponse origin2 rp (coerce c1) req resp of
+                      Left x -> x === Fido2.OriginDidNotMatch
+    it "fails if rpIds do not match" $ property $
+      \( coerce @Text -> rp1,
+         coerce @Text -> rp2,
+         coerce @ByteString -> challenge,
+         coerce @Text -> origin,
+         resp',
+         clientData,
+         attestationObject,
+         authData
+         ) ->
+          rp1 /= rp2
+            ==> let resp =
+                      (resp' :: Fido2.AuthenticatorAttestationResponse)
+                        { Fido2.clientData =
+                            clientData
+                              { Fido2.typ = Fido2.Create,
+                                Fido2.challenge = challenge,
+                                Fido2.origin = origin
+                              },
+                          Fido2.attestationObject =
+                            attestationObject
+                              { Fido2.authData =
+                                  authData
+                                    { Fido2.rpIdHash = Hash.hash (Text.encodeUtf8 $ (coerce @_ @Text rp2))
+                                    }
+                              }
+                        }
+                 in case Fido2.verifyAttestationResponse origin rp1 challenge undefined resp of
+                      Left x -> x === Fido2Attestation.RpIdMismatch
+    it "fails if user not present" $ property $
+      \( coerce @Text -> rp,
+         coerce @ByteString -> challenge,
+         coerce @Text -> origin,
+         resp',
+         clientData,
+         attestationObject,
+         authData
+         ) ->
+          let resp =
+                (resp' :: Fido2.AuthenticatorAttestationResponse)
+                  { Fido2.clientData =
+                      clientData
+                        { Fido2.typ = Fido2.Create,
+                          Fido2.challenge = challenge,
+                          Fido2.origin = origin
+                        },
+                    Fido2.attestationObject =
+                      attestationObject
+                        { Fido2.authData =
+                            authData
+                              { Fido2.rpIdHash = Hash.hash (Text.encodeUtf8 $ (coerce @_ @Text rp)),
+                                Fido2.userPresent = False
+                              }
+                        }
+                  }
+           in case Fido2.verifyAttestationResponse origin rp challenge undefined resp of
+                Left x -> x === Fido2Attestation.UserNotPresent
+    it "fails if userverification requirement doesnt match" $ property $
+      \( coerce @Text -> rp,
+         coerce @ByteString -> challenge,
+         coerce @Text -> origin,
+         resp',
+         clientData,
+         attestationObject,
+         authData
+         ) ->
+          let resp =
+                (resp' :: Fido2.AuthenticatorAttestationResponse)
+                  { Fido2.clientData =
+                      clientData
+                        { Fido2.typ = Fido2.Create,
+                          Fido2.challenge = challenge,
+                          Fido2.origin = origin
+                        },
+                    Fido2.attestationObject =
+                      attestationObject
+                        { Fido2.authData =
+                            authData
+                              { Fido2.rpIdHash = Hash.hash (Text.encodeUtf8 $ (coerce @_ @Text rp)),
+                                Fido2.userPresent = True,
+                                Fido2.userVerified = False
+                              }
+                        }
+                  }
+           in case Fido2.verifyAttestationResponse origin rp challenge Fido2.UserVerificationRequired resp of
+                Left x -> x === Fido2Attestation.UserNotVerified
+    it "fails if no attested credential data" $ property $
+      \( coerce @Text -> rp,
+         coerce @ByteString -> challenge,
+         coerce @Text -> origin,
+         resp',
+         clientData,
+         attestationObject,
+         authData
+         ) ->
+          let resp =
+                (resp' :: Fido2.AuthenticatorAttestationResponse)
+                  { Fido2.clientData =
+                      clientData
+                        { Fido2.typ = Fido2.Create,
+                          Fido2.challenge = challenge,
+                          Fido2.origin = origin
+                        },
+                    Fido2.attestationObject =
+                      attestationObject
+                        { Fido2.authData =
+                            authData
+                              { Fido2.rpIdHash = Hash.hash (Text.encodeUtf8 $ (coerce @_ @Text rp)),
+                                Fido2.userPresent = True,
+                                Fido2.attestedCredentialData = Nothing
+                              }
+                        }
+                  }
+           in case Fido2.verifyAttestationResponse origin rp challenge Fido2.UserVerificationPreferred resp of
+                Left x -> x === Fido2Attestation.NoAttestedCredentialDataFound
+    it "fails on unsupported attestation format" $ property $
+      \( coerce @Text -> rp,
+         coerce @ByteString -> challenge,
+         coerce @Text -> origin,
+         resp',
+         clientData,
+         attestationObject,
+         authData
+         ) ->
+          let resp =
+                (resp' :: Fido2.AuthenticatorAttestationResponse)
+                  { Fido2.clientData =
+                      clientData
+                        { Fido2.typ = Fido2.Create,
+                          Fido2.challenge = challenge,
+                          Fido2.origin = origin
+                        },
+                    Fido2.attestationObject =
+                      attestationObject
+                        { Fido2.authData =
+                            authData
+                              { Fido2.rpIdHash = Hash.hash (Text.encodeUtf8 $ (coerce @_ @Text rp)),
+                                Fido2.userPresent = True,
+                                Fido2.attestedCredentialData = Nothing
+                              },
+                          Fido2.fmt = "unsupported"
+                        }
+                  }
+           in case Fido2.verifyAttestationResponse origin rp challenge Fido2.UserVerificationPreferred resp of
+                Left x -> x === Fido2Attestation.UnsupportedAttestationFormat
+    it "fails on non-empty attStmt for none format" $ property $
+      \( coerce @Text -> rp,
+         coerce @ByteString -> challenge,
+         coerce @Text -> origin,
+         resp',
+         clientData,
+         attestationObject,
+         authData,
+         coerce @RandomAttStmt -> attStmt,
+         attData
+         ) ->
+          length attStmt >= 1 && not (isNothing attData)
+            ==> let resp =
+                      (resp' :: Fido2.AuthenticatorAttestationResponse)
+                        { Fido2.clientData =
+                            clientData
+                              { Fido2.typ = Fido2.Create,
+                                Fido2.challenge = challenge,
+                                Fido2.origin = origin
+                              },
+                          Fido2.attestationObject =
+                            attestationObject
+                              { Fido2.authData =
+                                  authData
+                                    { Fido2.rpIdHash = Hash.hash (Text.encodeUtf8 $ (coerce @_ @Text rp)),
+                                      Fido2.userPresent = True,
+                                      Fido2.attestedCredentialData = attData
+                                    },
+                                Fido2.fmt = "none",
+                                Fido2.attStmt = attStmt
+                              }
+                        }
+                 in case Fido2.verifyAttestationResponse origin rp challenge Fido2.UserVerificationPreferred resp of
+                      Left x -> x === Fido2Attestation.InvalidAttestationStatement
+    it "Can show Error" $ property $ \(err :: Fido2Attestation.Error) -> total . show $ err
+  describe "RegisterAndLogin"
     $ it "tests whether the fixed register and login responses are matching"
     $ do
       Fido2.PublicKeyCredential {response} <-

--- a/tests/Util.hs
+++ b/tests/Util.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Util where
+
+import qualified Codec.Serialise as Serialise
+import qualified Codec.Serialise.Properties as Serialise.Properties
+import Test.Hspec (SpecWith, it)
+import Test.QuickCheck (Arbitrary, property)
+
+roundtrips :: forall a. (Eq a, Show a, Serialise.Serialise a, Arbitrary a) => SpecWith ()
+roundtrips = do
+  it "serialiseIdentity" $ property $ \(key :: a) ->
+    Serialise.Properties.serialiseIdentity key
+  it "flatTermIdentity" $ property $ \(key :: a) ->
+    Serialise.Properties.flatTermIdentity key
+  it "hasValidFlatTerm" $ property $ \(key :: a) ->
+    Serialise.Properties.hasValidFlatTerm key


### PR DESCRIPTION
The current webauthn standard is rather ambigious again. So I think
there are some mistakes in the implementation that make our public
key decoder too crypto-agile.

The new draft of the webauthn standard is not ambigious, but also
has an issue I'd like to be clarified first:

w3c/webauthn#1446

it probably means `alg` should imply `crv` and we should remove
support for Ed448 or wait for the spec to be more fleshed out

Fixes https://github.com/arianvp/haskell-fido2/issues/20